### PR TITLE
Lock bulk queue while processing indexing request

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,9 @@ Metrics/ClassLength:
 Metrics/ModuleLength:
   Max: 200
 
+Metrics/AbcSize:
+  Max: 20
+
 # Disable for specs
 Metrics/BlockLength:
   Exclude:

--- a/lib/crawler/api/crawl.rb
+++ b/lib/crawler/api/crawl.rb
@@ -77,11 +77,6 @@ module Crawler
         end
       end
 
-      # No errors should be retried by default (see App Search subclass for a version with retries)
-      def retryable_error?(_error)
-        false
-      end
-
       #---------------------------------------------------------------------------------------------
       def coordinator
         @coordinator ||= Crawler::Coordinator.new(self)

--- a/lib/crawler/api/crawl.rb
+++ b/lib/crawler/api/crawl.rb
@@ -20,7 +20,7 @@ module Crawler
       attr_reader :config, :crawl_queue, :seen_urls, :sink, :outcome, :outcome_message
       attr_accessor :executor
 
-      def initialize(config) # rubocop:disable Metrics/AbcSize
+      def initialize(config)
         raise ArgumentError, 'Invalid config' unless config.is_a?(Config)
         raise ArgumentError, 'Missing domain allowlist' if config.domain_allowlist.empty?
         raise ArgumentError, 'Seed URLs need to be an enumerator' unless config.seed_urls.is_a?(Enumerator)
@@ -124,7 +124,7 @@ module Crawler
       # Returns a hash with crawl-specific status information
       # Note: This is used by the `EventGenerator` class for crawl-status events and by the Crawler Status API.
       #       Please update OpenAPI specs if you add any new fields here.
-      def status # rubocop:disable Metrics/AbcSize
+      def status
         {
           queue_size: crawl_queue.length,
           pages_visited: stats.fetched_pages_count,

--- a/lib/crawler/coordinator.rb
+++ b/lib/crawler/coordinator.rb
@@ -456,7 +456,7 @@ module Crawler
           raise ArgumentError, error
         end
       end
-    rescue Errors::BulkQueueProcessingError
+    rescue Errors::BulkQueueLockedError
       log = <<~LOG.squish
         Crawl result could not be added to queue because an indexing operation is in process.
         Retrying in #{RETRY_INTERVAL} seconds...

--- a/lib/crawler/http_client.rb
+++ b/lib/crawler/http_client.rb
@@ -197,7 +197,7 @@ module Crawler
     end
 
     #-------------------------------------------------------------------------------------------------
-    def new_connection_manager # rubocop:disable Metrics/AbcSize
+    def new_connection_manager
       builder = PoolingHttpClientConnectionManagerBuilder.create
       builder.set_ssl_socket_factory(https_socket_factory)
       builder.set_dns_resolver(dns_resolver)
@@ -315,7 +315,7 @@ module Crawler
 
     #-------------------------------------------------------------------------------------------------
     # Returns a proxy host object to be used for all connections
-    def proxy_host # rubocop:disable Metrics/AbcSize
+    def proxy_host
       return nil unless config.http_proxy_host
 
       logger.debug(<<~LOG.squish)

--- a/lib/crawler/http_utils/response.rb
+++ b/lib/crawler/http_utils/response.rb
@@ -72,7 +72,7 @@ module Crawler
         v.is_a?(Array) ? v.first : v
       end
 
-      def headers # rubocop:disable Metrics/AbcSize
+      def headers
         @headers ||= apache_response.headers.each_with_object({}) do |h, o|
           key = h.get_name.downcase
 

--- a/lib/crawler/output_sink/elasticsearch.rb
+++ b/lib/crawler/output_sink/elasticsearch.rb
@@ -45,7 +45,7 @@ module Crawler
           doc = parametrized_doc(crawl_result)
           index_op = { 'index' => { '_index' => index_name, '_id' => doc['id'] } }
 
-          process unless operation_queue.will_fit?(index_op, doc)
+          flush unless operation_queue.will_fit?(index_op, doc)
 
           operation_queue.add(
             index_op,
@@ -59,7 +59,7 @@ module Crawler
       end
 
       def close
-        process
+        flush
         msg = <<~LOG.squish
           All indexing operations completed.
           Successfully indexed #{@completed[:docs_count]} docs with a volume of #{@completed[:docs_volume]} bytes.
@@ -68,10 +68,10 @@ module Crawler
         system_logger.info(msg)
       end
 
-      def process # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      def flush # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
         body = operation_queue.pop_all
         if body.empty?
-          system_logger.debug('Queue was empty when attempting to process.')
+          system_logger.debug('Queue was empty when attempting to flush.')
           return
         end
 

--- a/lib/errors.rb
+++ b/lib/errors.rb
@@ -7,13 +7,6 @@
 # frozen_string_literal: true
 
 class Errors
-  # Raised when attempting to add a crawl result to the bulk queue, but it is currently flushing.
-  # The bulk queue is single-threaded, but receives crawl results from multi-threaded processes.
-  # This error is raised to prevent overloading the queue if Elasticsearch indexing is failing repeatedly
-  #   and performing exponential backoff.
-  # This error should be treated as retryable.
-  class BulkQueueLockedError < StandardError; end
-
   # Raised only if the queue item added somehow overflows the queue threshold.
   # The queue threshold is checked before an item is added so this error shouldn't occur.
   # If this error occurs, something is wrong with the interaction between the Elasticsearch sink and BulkQueue.

--- a/lib/errors.rb
+++ b/lib/errors.rb
@@ -1,0 +1,21 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+
+# frozen_string_literal: true
+
+class Errors
+  # Raised when attempting to add a crawl result to the bulk queue, but it is currently flushing.
+  # The bulk queue is single-threaded, but receives crawl results from multi-threaded processes.
+  # This error is raised to prevent overloading the queue if Elasticsearch indexing is failing repeatedly
+  #   and performing exponential backoff.
+  # This error should be treated as retryable.
+  class BulkQueueProcessingError < StandardError; end
+
+  # Raised only if the queue item added somehow overflows the queue threshold.
+  # The queue threshold is checked before an item is added so this error shouldn't occur.
+  # If this error occurs, something is wrong with the interaction between the Elasticsearch sink and BulkQueue.
+  class BulkQueueOverflowError < StandardError; end
+end

--- a/lib/errors.rb
+++ b/lib/errors.rb
@@ -12,7 +12,7 @@ class Errors
   # This error is raised to prevent overloading the queue if Elasticsearch indexing is failing repeatedly
   #   and performing exponential backoff.
   # This error should be treated as retryable.
-  class BulkQueueProcessingError < StandardError; end
+  class BulkQueueLockedError < StandardError; end
 
   # Raised only if the queue item added somehow overflows the queue threshold.
   # The queue threshold is checked before an item is added so this error shouldn't occur.

--- a/lib/errors.rb
+++ b/lib/errors.rb
@@ -11,4 +11,11 @@ class Errors
   # The queue threshold is checked before an item is added so this error shouldn't occur.
   # If this error occurs, something is wrong with the interaction between the Elasticsearch sink and BulkQueue.
   class BulkQueueOverflowError < StandardError; end
+
+  # Raised when attempting to add a crawl result to the sink, but it is currently locked.
+  # This is specific for Elasticsearch sink. Basically the sink is single-threaded but
+  # receives crawl results from multi-threaded processes. This error is raised to prevent
+  # overloading the queue if Elasticsearch indexing is failing repeatedly and performing
+  # exponential backoff. This error should be treated as retryable.
+  class SinkLockedError < StandardError; end
 end

--- a/lib/utility/bulk_queue.rb
+++ b/lib/utility/bulk_queue.rb
@@ -8,14 +8,14 @@
 
 require 'elasticsearch/api'
 
+require_dependency File.join(__dir__, '..', 'errors')
+
 module Utility
   class BulkQueue
     # Maximum number of operations in BULK Elasticsearch operation that will ingest the data
     DEFAULT_OP_COUNT_THRESHOLD = 100
     # Maximum size of either whole BULK Elasticsearch operation or one document in it
     DEFAULT_SIZE_THRESHOLD = 1 * 1024 * 1024 # 1 megabyte
-
-    class QueueOverflowError < StandardError; end
 
     def initialize(op_count_threshold, size_threshold, system_logger)
       @op_count_threshold = (op_count_threshold || DEFAULT_OP_COUNT_THRESHOLD).freeze
@@ -41,7 +41,7 @@ module Utility
     end
 
     def add(operation, payload = nil)
-      raise QueueOverflowError unless will_fit?(operation, payload)
+      raise Errors::BulkQueueOverflowError unless will_fit?(operation, payload)
 
       operation_size = bytesize(operation)
       payload_size = bytesize(payload)

--- a/lib/utility/es_client.rb
+++ b/lib/utility/es_client.rb
@@ -13,7 +13,7 @@ module Utility
   class EsClient < ::Elasticsearch::Client
     USER_AGENT = 'elastic-web-crawler-'
     MAX_RETRIES = 3
-    REQUEST_TIMEOUT = 30 # seconds
+    REQUEST_TIMEOUT = 10 # seconds
     FAILED_BULKS_DIR = 'output/failed_payloads' # directory that failed bulk payloads are output to
 
     class IndexingFailedError < StandardError

--- a/spec/lib/crawler/coordinator_spec.rb
+++ b/spec/lib/crawler/coordinator_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe(Crawler::Coordinator) do
       end
 
       it 'should retry exceptions if possible' do
-        error = Errors::BulkQueueProcessingError.new
+        error = Errors::BulkQueueLockedError.new
         expect(crawl.sink).to receive(:write).twice.and_wrap_original do |method, *args|
           unless @called_before
             @called_before = true

--- a/spec/lib/crawler/output_sink/elasticsearch_spec.rb
+++ b/spec/lib/crawler/output_sink/elasticsearch_spec.rb
@@ -321,7 +321,7 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
     end
   end
 
-  describe '#process' do
+  describe '#flush' do
     let(:operation) do
       [
         { index: { _index: 'my-index', _id: '1234' } },
@@ -337,7 +337,7 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
       expect(es_client).to receive(:bulk).with(hash_including(body: operation, pipeline: default_pipeline))
       expect(system_logger).to receive(:info).with('Successfully indexed 1 docs.')
 
-      subject.process
+      subject.flush
     end
 
     context('when an error occurs during indexing') do
@@ -349,13 +349,13 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
         expect(es_client).to receive(:bulk).with(hash_including(body: operation, pipeline: default_pipeline))
         expect(system_logger).to receive(:warn).with('Bulk index failed: BOOM')
 
-        subject.process
+        subject.flush
       end
     end
   end
 
   describe '#ingestion_stats' do
-    context 'when process was not triggered' do
+    context 'when flush was not triggered' do
       let(:crawl_result) { FactoryBot.build(:html_crawl_result) }
       before(:each) do
         allow(bulk_queue).to receive(:bytesize).and_return(10) # arbitrary
@@ -372,7 +372,7 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
       end
     end
 
-    context 'when process was triggered' do
+    context 'when flush was triggered' do
       let(:operation) { 'bulk: delete something \n insert something else' }
 
       before(:each) do
@@ -399,7 +399,7 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
             subject.write(FactoryBot.build(:html_crawl_result, url: "http://real.com/#{x}"))
           end
 
-          subject.process
+          subject.flush
         end
 
         it 'returns expected docs_count' do
@@ -429,7 +429,7 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
             subject.write(FactoryBot.build(:html_crawl_result, url: "http://real.com/#{x}"))
           end
 
-          subject.process
+          subject.flush
         end
 
         it 'returns expected docs_count' do

--- a/spec/lib/utility/bulk_queue_spec.rb
+++ b/spec/lib/utility/bulk_queue_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe(Utility::BulkQueue) do
       end
 
       it 'raises an error' do
-        expect { subject.add('some-op') }.to raise_error(Utility::BulkQueue::QueueOverflowError)
+        expect { subject.add('some-op') }.to raise_error(Errors::BulkQueueOverflowError)
       end
     end
 

--- a/spec/lib/utility/bulk_queue_spec.rb
+++ b/spec/lib/utility/bulk_queue_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe(Utility::BulkQueue) do
 
   before(:each) do
     allow(system_logger).to receive(:debug)
+    allow(system_logger).to receive(:error)
   end
 
   describe '#add' do


### PR DESCRIPTION
### Closes https://github.com/elastic/crawler/issues/42

The coordinator currently doesn't care about the state of the bulk queue, and will add a crawl result to the queue pool whenever it is finished crawling a page.
This is not thread-safe as multiple threads attempting to add to the queue causes overwrites and potentially lost data.
This is more noticeable since implementing [retries with exponential backoff for ES indexing](https://github.com/elastic/crawler/pull/39).

This change adds a mutex lock to the `write` method in the `Elasticsearch` sink. If `write` is called, the lock is enabled, and nothing can be added to the pool until the lock is lifted.

This effectively pauses crawl requests when ES indexing is overloaded. This should only impact performance if an ES instance is unhealthy or there are network issues. I think this is acceptable as the user should investigate these things anyway.

#### Pre-Review Checklist
- [x] This PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `crawler.yml.example` and `elasticsearch.yml.example`)
- [x] This PR has a meaningful title
- [x] This PR links to all relevant GitHub issues that it fixes or partially addresses
    - If there is no GitHub issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v0.1.0`)
