### PR TITLE
Update domains format in crawler config.yml

### DIFF
--- a/config/crawler.yml.example
+++ b/config/crawler.yml.example
@@ -9,13 +9,22 @@
 #
 ## ------------------------------- Crawler ------------------------------------
 #
-## The domain(s) that Crawler will crawl.
-#domain_allowlist:
-#  - http://localhost:8000
+## The domain(s) that Crawler will crawl. This is an array. All domains in this
+##   array will be crawled concurrently by the Crawler with a shared output.
+##   They are separated to allow for domain-specific configurations.
+##
+##   `domains[].url`           - (Required) The base URL for this domain
+##   `domains[].seed_urls`     - (Optional) The entry point(s) for crawl jobs.
+##								      If this is empty, the `url` will be used.
+##   `domains[].sitemap_urls`  - (Optional) the location(s) of sitemap files
 #
-## The URLs used to seed the crawl. Must have the same host(s) as `domain_allowlist`
-#seed_urls:
-#  - http://localhost:8000
+#domains:
+#  - url: http://localhost:8000
+#    seed_urls:
+#      - http://localhost:8000/foo
+#      - http://localhost:8000/bar
+#    sitemap_urls:
+#      - http://localhost:8000/sitemap.xml
 #
 ## Where to send the results. Possible values are console, file, or elasticsearch
 #output_sink: elasticsearch

--- a/config/examples/parks-australia.yml
+++ b/config/examples/parks-australia.yml
@@ -1,13 +1,11 @@
 # This is a sample config file for crawling the parksaustralia.gov.au website writing output to an ES index
 
 # Domains allowed for the crawl
-domain_allowlist:
-  - https://parksaustralia.gov.au
-
-# URLs used to seed the crawl
-seed_urls:
-  - https://parksaustralia.gov.au
-  - https://parksaustralia.gov.au/news/
+domains:
+  - url: https://parksaustralia.gov.au
+    seed_urls:
+      - https://parksaustralia.gov.au
+      - https://parksaustralia.gov.au/news/
 
 # Where to send the results. Possible values are console, file, or elasticsearch
 output_sink: elasticsearch

--- a/lib/crawler/api/config.rb
+++ b/lib/crawler/api/config.rb
@@ -304,7 +304,7 @@ module Crawler
           if domain[:seed_urls]&.any?
             domain[:seed_urls]
           else
-            [domain[:url]]
+            ["#{domain[:url]}/"]
           end
         end.flatten
 

--- a/lib/crawler/api/config.rb
+++ b/lib/crawler/api/config.rb
@@ -296,13 +296,13 @@ module Crawler
       #---------------------------------------------------------------------------------------------
       def configure_seed_urls!
         # use the main url if no seed_urls were configured
-        seed_urls = domains.map do |domain|
+        seed_urls = domains.flat_map do |domain|
           if domain[:seed_urls]&.any?
             domain[:seed_urls]
           else
             ["#{domain[:url]}/"]
           end
-        end.flatten
+        end
 
         # Convert seed URLs into an enumerator if needed
         @seed_urls = seed_urls.each unless seed_urls.is_a?(Enumerator)

--- a/lib/crawler/api/config.rb
+++ b/lib/crawler/api/config.rb
@@ -280,12 +280,8 @@ module Crawler
         @domain_allowlist = domains.map do |domain|
           raise ArgumentError, 'Each domain requires a url' unless domain[:url]
 
-          domain[:url]
-        end
-
-        @domain_allowlist.map! do |domain|
-          validate_domain!(domain)
-          Crawler::Data::Domain.new(domain)
+          validate_domain!(domain[:url])
+          Crawler::Data::Domain.new(domain[:url])
         end
       end
 

--- a/spec/fixtures/crawl.yml
+++ b/spec/fixtures/crawl.yml
@@ -1,11 +1,9 @@
 # Domains allowed for the crawl
-domain_allowlist:
-  - https://localhost:80
-
-# URLs used to seed the crawl
-seed_urls:
-  - https://localhost:80
-  - https://localhost:80/news/
+domains:
+  - url: https://localhost:80
+    seed_urls:
+      - https://localhost:80
+      - https://localhost:80/news/
 
 # Where to send the results. Possible values are console, file, or elasticsearch
 output_sink: elasticsearch

--- a/spec/integration/timeouts/request_timeout_spec.rb
+++ b/spec/integration/timeouts/request_timeout_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'Request to a site that is sending the data back really slowly' d
     results = FauxCrawl.run(
       Faux.site, # This will never actually be called, since we seed the crawl with the slow site
       timeouts: { request_timeout: 2 },
-      seed_urls: [slow_server.root_url]
+      url: slow_server.root_url
     )
 
     # Should only have a single result (home page)

--- a/spec/lib/crawler/api/config_spec.rb
+++ b/spec/lib/crawler/api/config_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe(Crawler::API::Config) do
 
     # https on port 443, http on port 80
     let(:expected_allowlist) { %W[#{domain1[:url]}:443 #{domain2[:url]}:80] }
-    let(:expected_seed_urls) { [domain2[:url]] + "#{domain1[:seed_urls]}/" }
+    let(:expected_seed_urls) { ["#{domain2[:url]}/"] + domain1[:seed_urls] }
 
     let(:output_dir) { '/tmp/crawler/example.com/123' }
 

--- a/spec/lib/crawler/api/config_spec.rb
+++ b/spec/lib/crawler/api/config_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe(Crawler::API::Config) do
 
     # https on port 443, http on port 80
     let(:expected_allowlist) { %W[#{domain1[:url]}:443 #{domain2[:url]}:80] }
-    let(:expected_seed_urls) { [domain2[:url]] + domain1[:seed_urls] }
+    let(:expected_seed_urls) { [domain2[:url]] + "#{domain1[:seed_urls]}/" }
 
     let(:output_dir) { '/tmp/crawler/example.com/123' }
 

--- a/spec/lib/crawler/api/config_spec.rb
+++ b/spec/lib/crawler/api/config_spec.rb
@@ -7,56 +7,123 @@
 # frozen_string_literal: true
 
 RSpec.describe(Crawler::API::Config) do
-  let(:domains) { ['http://example.com'] }
-  let(:normalized_domains) { ['http://example.com:80'] }
+  describe '#initialize' do
+    let(:domain1) do
+      {
+        url: 'https://domain1.com',
+        seed_urls: %w[https://domain1.com/forum https://domain1.com/wiki],
+        sitemap_urls: %w[https://domain1.com/sitemap/foo.xml]
+      }
+    end
+    let(:domain2) { { url: 'http://domain2.com' } }
+    let(:domains) { [domain1, domain2] }
 
-  let(:seed_urls) { ['http://example.com/'] }
-  let(:output_dir) { '/tmp/crawler/example.com/123' }
+    # https on port 443, http on port 80
+    let(:expected_allowlist) { %W[#{domain1[:url]}:443 #{domain2[:url]}:80] }
+    let(:expected_seed_urls) { [domain2[:url]] + domain1[:seed_urls] }
 
-  #-------------------------------------------------------------------------------------------------
-  context 'constructor' do
+    let(:output_dir) { '/tmp/crawler/example.com/123' }
+
     it 'should fail when provided with unknown options' do
       expect do
         Crawler::API::Config.new(fubar: 42)
       end.to raise_error(ArgumentError, /Unexpected configuration options.*fubar/)
     end
 
-    #-----------------------------------------------------------------------------------------------
-    it 'should use the console sink by default' do
+    it 'can define a crawl with elasticsearch output' do
       config = Crawler::API::Config.new(
-        domain_allowlist: domains,
-        seed_urls:
-      )
-      expect(config.output_sink).to eq(:console)
-    end
-
-    #-----------------------------------------------------------------------------------------------
-    it 'can define a crawl with console output' do
-      config = Crawler::API::Config.new(
-        domain_allowlist: domains,
-        seed_urls:,
-        output_sink: :console
+        domains:,
+        output_sink: :elasticsearch
       )
 
-      expect(config.domain_allowlist.map(&:to_s)).to eq(normalized_domains)
-      expect(config.seed_urls.map(&:to_s).to_a).to eq(seed_urls)
-      expect(config.output_sink).to eq(:console)
+      expect(config.domain_allowlist.map(&:to_s)).to match_array(expected_allowlist)
+      expect(config.seed_urls.map(&:to_s).to_a).to match_array(expected_seed_urls)
+      expect(config.output_sink).to eq(:elasticsearch)
       expect(config.output_dir).to be_nil
     end
 
-    #-----------------------------------------------------------------------------------------------
     it 'can define a crawl with file output' do
       config = Crawler::API::Config.new(
-        domain_allowlist: domains,
-        seed_urls:,
+        domains:,
         output_sink: :file,
         output_dir:
       )
 
-      expect(config.domain_allowlist.map(&:to_s)).to eq(normalized_domains)
-      expect(config.seed_urls.map(&:to_s).to_a).to eq(seed_urls)
+      expect(config.domain_allowlist.map(&:to_s)).to match_array(expected_allowlist)
+      expect(config.seed_urls.map(&:to_s).to_a).to match_array(expected_seed_urls)
       expect(config.output_sink).to eq(:file)
       expect(config.output_dir).to eq(output_dir)
+    end
+
+    it 'should use the console sink by default' do
+      config = Crawler::API::Config.new(
+        domains:
+      )
+
+      expect(config.domain_allowlist.map(&:to_s)).to match_array(expected_allowlist)
+      expect(config.seed_urls.map(&:to_s).to_a).to match_array(expected_seed_urls)
+      expect(config.output_sink).to eq(:console)
+      expect(config.output_dir).to be_nil
+    end
+
+    context 'when a domain is missing a main URL' do
+      let(:domain2) { { foo: 'bar' } }
+
+      it 'should raise an argument error' do
+        expect do
+          Crawler::API::Config.new(
+            domains:
+          )
+        end.to raise_error(ArgumentError, 'Each domain requires a url')
+      end
+    end
+
+    context 'when a domain URL is invalid' do
+      let(:domain2) { { url: 'huh?' } }
+
+      it 'should raise an argument error' do
+        expect do
+          Crawler::API::Config.new(
+            domains:
+          )
+        end.to raise_error(ArgumentError, 'Domain "huh?" does not have a URL scheme')
+      end
+    end
+
+    context 'when a domain URL has a path' do
+      let(:domain2) { { url: 'http://domain2.com/baa' } }
+
+      it 'should raise an argument error' do
+        expect do
+          Crawler::API::Config.new(
+            domains:
+          )
+        end.to raise_error(ArgumentError, 'Domain "http://domain2.com/baa" cannot have a path')
+      end
+    end
+
+    context 'when a domain URL is not an HTTP(S) site' do
+      let(:domain2) { { url: 'file://location/to/file.txt' } }
+
+      it 'should raise an argument error' do
+        expect do
+          Crawler::API::Config.new(
+            domains:
+          )
+        end.to raise_error(ArgumentError, 'Domain "file://location/to/file.txt" is not an HTTP(S) site')
+      end
+    end
+
+    context 'when domains is empty' do
+      let(:domains) { [] }
+
+      it 'should raise an argument error' do
+        expect do
+          Crawler::API::Config.new(
+            domains:
+          )
+        end.to raise_error(ArgumentError, 'Needs at least one domain')
+      end
     end
   end
 end

--- a/spec/lib/crawler/api/crawl_spec.rb
+++ b/spec/lib/crawler/api/crawl_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe(Crawler::API::Crawl) do
 
   #-------------------------------------------------------------------------------------------------
   it 'has a config' do
-    expect(subject.config.seed_urls.map(&:to_s).to_a).to eq([url])
+    expect(subject.config.seed_urls.map(&:to_s).to_a).to eq(["#{url}/"])
     expect(subject.config.output_sink).to eq(:console)
   end
 

--- a/spec/lib/crawler/api/crawl_spec.rb
+++ b/spec/lib/crawler/api/crawl_spec.rb
@@ -7,13 +7,14 @@
 # frozen_string_literal: true
 
 RSpec.describe(Crawler::API::Crawl) do
-  let(:seed_url) { 'http://example.com/' }
-  let(:parsed_url) { Crawler::Data::URL.parse(seed_url) }
+  let(:url) { 'http://example.com' }
+  let(:parsed_url) { Crawler::Data::URL.parse(url) }
 
   let(:crawl_config) do
     Crawler::API::Config.new(
-      domain_allowlist: ['http://example.com'],
-      seed_urls: [seed_url]
+      domains: [
+        { url: },
+      ]
     )
   end
 
@@ -24,7 +25,7 @@ RSpec.describe(Crawler::API::Crawl) do
       content: mock_seed_body
     )
   end
-  let(:executor) { Crawler::MockExecutor.new(seed_url => mock_crawl_result) }
+  let(:executor) { Crawler::MockExecutor.new(url => mock_crawl_result) }
 
   subject do
     described_class.new(crawl_config).tap do |crawl|
@@ -39,7 +40,7 @@ RSpec.describe(Crawler::API::Crawl) do
 
   #-------------------------------------------------------------------------------------------------
   it 'has a config' do
-    expect(subject.config.seed_urls.map(&:to_s).to_a).to eq([seed_url])
+    expect(subject.config.seed_urls.map(&:to_s).to_a).to eq([url])
     expect(subject.config.output_sink).to eq(:console)
   end
 

--- a/spec/lib/crawler/api/crawl_spec.rb
+++ b/spec/lib/crawler/api/crawl_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe(Crawler::API::Crawl) do
   let(:crawl_config) do
     Crawler::API::Config.new(
       domains: [
-        { url: },
+        { url: }
       ]
     )
   end

--- a/spec/lib/crawler/coordinator_spec.rb
+++ b/spec/lib/crawler/coordinator_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe(Crawler::Coordinator) do
   let(:sitemap_url) { URI.join(domain, '/sitemap.xml') }
   let(:sitemap_urls) { [sitemap_url] }
 
+  let(:domains) { [{ url: domain, seed_urls:, sitemap_urls: }] }
+
   let(:results_collection) { ResultsCollection.new }
   let(:crawl_configuration) do
     {
-      domain_allowlist: [domain],
-      seed_urls:,
-      sitemap_urls:,
+      domains:,
       results_collection:
     }
   end

--- a/spec/lib/crawler/data/url_queue/memory_only_spec.rb
+++ b/spec/lib/crawler/data/url_queue/memory_only_spec.rb
@@ -7,13 +7,11 @@
 # frozen_string_literal: true
 
 RSpec.describe(Crawler::Data::UrlQueue::MemoryOnly) do
-  let(:domains) { ['http://example.com'] }
-  let(:seed_urls) { ['http://example.com/'] }
+  let(:domains) { [{ url: 'http://example.com' }] }
 
   let(:config) do
     Crawler::API::Config.new(
-      domain_allowlist: domains,
-      seed_urls:,
+      domains:,
       url_queue: :memory_only
     )
   end

--- a/spec/lib/crawler/data/url_queue_spec.rb
+++ b/spec/lib/crawler/data/url_queue_spec.rb
@@ -7,13 +7,11 @@
 # frozen_string_literal: true
 
 RSpec.describe(Crawler::Data::UrlQueue) do
-  let(:domains) { ['http://example.com'] }
-  let(:seed_urls) { ['http://example.com/'] }
+  let(:domains) { [{ url: 'http://example.com' }] }
 
   let(:config) do
     Crawler::API::Config.new(
-      domain_allowlist: domains,
-      seed_urls:
+      domains:
     )
   end
 

--- a/spec/lib/crawler/event_generator_spec.rb
+++ b/spec/lib/crawler/event_generator_spec.rb
@@ -7,12 +7,10 @@
 # frozen_string_literal: true
 
 RSpec.describe(Crawler::EventGenerator) do
-  let(:domains) { ['http://example.com'] }
-  let(:seed_urls) { ['http://example.com/'] }
+  let(:domains) { [{ url: 'http://example.com' }] }
   let(:config) do
     Crawler::API::Config.new(
-      domain_allowlist: domains,
-      seed_urls:
+      domains:
     )
   end
 

--- a/spec/lib/crawler/http_client_spec.rb
+++ b/spec/lib/crawler/http_client_spec.rb
@@ -279,11 +279,11 @@ RSpec.describe(Crawler::HttpClient) do
       let(:ca_certs) { [] }
       let(:ssl_mode) { 'full' }
       let(:url) { 'https://example.org' }
+      let(:domains) { [{ url: }] }
 
       let(:crawler_config) do
         Crawler::API::Config.new(
-          domain_allowlist: [url],
-          seed_urls: [url],
+          domains:,
           ssl_ca_certificates: ca_certs,
           ssl_verification_mode: ssl_mode
         )

--- a/spec/lib/crawler/output_sink/elasticsearch_spec.rb
+++ b/spec/lib/crawler/output_sink/elasticsearch_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
   let(:subject) { described_class.new(config) }
   let(:config) do
     Crawler::API::Config.new(
-      domain_allowlist: domains,
-      seed_urls:,
+      domains:,
       output_sink: 'elasticsearch',
       output_index: index_name,
       elasticsearch: {
@@ -22,8 +21,7 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
     )
   end
 
-  let(:domains) { ['http://example.com'] }
-  let(:seed_urls) { ['http://example.com/'] }
+  let(:domains) { [{ url: 'http://example.com' }] }
   let(:index_name) { 'my-index' }
 
   let(:index_name) { 'some-index-name' }
@@ -64,8 +62,7 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
     context 'when output index is missing' do
       let(:config) do
         Crawler::API::Config.new(
-          domain_allowlist: domains,
-          seed_urls:,
+          domains:,
           output_sink: 'elasticsearch'
         )
       end
@@ -78,8 +75,7 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
     context 'when elasticsearch config is missing' do
       let(:config) do
         Crawler::API::Config.new(
-          domain_allowlist: domains,
-          seed_urls:,
+          domains:,
           output_sink: 'elasticsearch',
           output_index: index_name
         )
@@ -109,8 +105,7 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
     context 'when elasticsearch.pipeline is not provided' do
       let(:config) do
         Crawler::API::Config.new(
-          domain_allowlist: domains,
-          seed_urls:,
+          domains:,
           output_sink: 'elasticsearch',
           output_index: index_name,
           elasticsearch: {
@@ -134,8 +129,7 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
     context 'when elasticsearch.pipeline_params are changed' do
       let(:config) do
         Crawler::API::Config.new(
-          domain_allowlist: domains,
-          seed_urls:,
+          domains:,
           output_sink: 'elasticsearch',
           output_index: index_name,
           elasticsearch: {
@@ -169,8 +163,7 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
     context 'when elasticsearch.pipeline_enabled is false' do
       let(:config) do
         Crawler::API::Config.new(
-          domain_allowlist: domains,
-          seed_urls:,
+          domains:,
           output_sink: 'elasticsearch',
           output_index: index_name,
           elasticsearch: {

--- a/spec/lib/crawler/output_sink/file_spec.rb
+++ b/spec/lib/crawler/output_sink/file_spec.rb
@@ -7,8 +7,7 @@
 # frozen_string_literal: true
 
 RSpec.describe(Crawler::OutputSink::File) do
-  let(:domains) { ['http://example.com'] }
-  let(:seed_urls) { ['http://example.com/'] }
+  let(:domains) { [{ url: 'http://example.com' }] }
 
   context '#initialize' do
     def new_sink(config)
@@ -17,8 +16,7 @@ RSpec.describe(Crawler::OutputSink::File) do
 
     it 'should require an output directory' do
       config = Crawler::API::Config.new(
-        domain_allowlist: domains,
-        seed_urls:,
+        domains:,
         output_sink: 'file'
       )
 
@@ -28,8 +26,7 @@ RSpec.describe(Crawler::OutputSink::File) do
     it 'should create the output directory' do
       dir = '/some/directory'
       config = Crawler::API::Config.new(
-        domain_allowlist: domains,
-        seed_urls:,
+        domains:,
         output_sink: 'file',
         output_dir: dir
       )

--- a/spec/lib/crawler/output_sink_spec.rb
+++ b/spec/lib/crawler/output_sink_spec.rb
@@ -7,14 +7,12 @@
 # frozen_string_literal: true
 
 RSpec.describe(Crawler::OutputSink) do
-  let(:domains) { ['http://example.com'] }
-  let(:seed_urls) { ['http://example.com/'] }
+  let(:domains) { [{ url: 'http://example.com' }] }
 
   context '.create' do
     it 'should validate the sync name' do
       config = Crawler::API::Config.new(
-        domain_allowlist: domains,
-        seed_urls:,
+        domains:,
         output_sink: 'magnetic-tape'
       )
 
@@ -25,8 +23,7 @@ RSpec.describe(Crawler::OutputSink) do
 
     it 'should return a new sink object of a correct type' do
       config = Crawler::API::Config.new(
-        domain_allowlist: domains,
-        seed_urls:,
+        domains:,
         output_sink: 'console'
       )
 

--- a/spec/lib/crawler/rule_engine/base_spec.rb
+++ b/spec/lib/crawler/rule_engine/base_spec.rb
@@ -7,10 +7,9 @@
 # frozen_string_literal: true
 
 RSpec.describe(Crawler::RuleEngine::Base) do
-  let(:domains) { ['http://example.com'] }
-  let(:seed_urls) { ['http://example.com/'] }
+  let(:domains) { [{ url: 'http://example.com' }] }
   let(:config) do
-    Crawler::API::Config.new(domain_allowlist: domains, seed_urls:,
+    Crawler::API::Config.new(domains:,
                              robots_txt_service: Crawler::RobotsTxtService.always_allow)
   end
   subject(:rule_engine) { described_class.new(config) }
@@ -35,8 +34,9 @@ RSpec.describe(Crawler::RuleEngine::Base) do
 
     context 'robots.txt' do
       let(:domain) { Crawler::Data::Domain.new('http://example.com') }
+      let(:domains) { [{ url: domain.to_s }] }
       let(:config) do
-        Crawler::API::Config.new(domain_allowlist: [domain.to_s], seed_urls:,
+        Crawler::API::Config.new(domains:,
                                  robots_txt_service: @robots_txt_service)
       end
 

--- a/spec/support/faux/faux_crawl.rb
+++ b/spec/support/faux/faux_crawl.rb
@@ -44,7 +44,8 @@ class FauxCrawl # rubocop:disable Metrics/ClassLength
   START_TIMEOUT = 20.seconds
 
   attr_reader :options, :sites, :site_containers, :timeouts, :content_extraction, :default_encoding, :crawl_id,
-              :url_queue, :auth, :user_agent, :seed_urls, :sitemap_urls, :domain_allowlist, :results, :expect_success
+              :url_queue, :auth, :user_agent, :url, :seed_urls, :sitemap_urls, :domain_allowlist, :results,
+              :expect_success
 
   delegate :crawl, to: :results
 
@@ -156,7 +157,7 @@ class FauxCrawl # rubocop:disable Metrics/ClassLength
       user_agent: user_agent,
       domains: [
         {
-          url: @url,
+          url: url,
           seed_urls: seed_urls,
           sitemap_urls: sitemap_urls
         }

--- a/spec/support/faux/faux_crawl.rb
+++ b/spec/support/faux/faux_crawl.rb
@@ -56,7 +56,8 @@ class FauxCrawl # rubocop:disable Metrics/ClassLength
     @url_queue = options.fetch(:url_queue, enterprise_search? ? :esqueues_me : :memory_only)
     @user_agent = options.fetch(:user_agent, 'Faux Crawler')
     @auth = options.fetch(:auth, nil)
-    @seed_urls = coerce_to_absolute_urls(options[:seed_urls] || ["#{Settings.faux_url}/"])
+    @url = options.fetch(:url, Settings.faux_url)
+    @seed_urls = coerce_to_absolute_urls(options[:seed_urls] || ["#{@url}/"])
     @sitemap_urls = coerce_to_absolute_urls(options[:sitemap_urls] || [])
     @domain_allowlist = seed_urls.map { |url| Crawler::Data::URL.parse(url).site }
     @content_extraction = options.fetch(:content_extraction, { enabled: false, mime_types: [] })
@@ -155,7 +156,7 @@ class FauxCrawl # rubocop:disable Metrics/ClassLength
       user_agent: user_agent,
       domains: [
         {
-          url: Settings.faux_url,
+          url: @url,
           seed_urls: seed_urls,
           sitemap_urls: sitemap_urls
         }

--- a/spec/support/faux/faux_crawl.rb
+++ b/spec/support/faux/faux_crawl.rb
@@ -12,7 +12,7 @@ require_relative 'results_collection'
 class FauxCrawl # rubocop:disable Metrics/ClassLength
   module Settings
     def self.faux_url
-      "http://#{faux_ip}:#{faux_port}/"
+      "http://#{faux_ip}:#{faux_port}"
     end
 
     def self.faux_ip
@@ -56,7 +56,7 @@ class FauxCrawl # rubocop:disable Metrics/ClassLength
     @url_queue = options.fetch(:url_queue, enterprise_search? ? :esqueues_me : :memory_only)
     @user_agent = options.fetch(:user_agent, 'Faux Crawler')
     @auth = options.fetch(:auth, nil)
-    @seed_urls = coerce_to_absolute_urls(options[:seed_urls] || [Settings.faux_url])
+    @seed_urls = coerce_to_absolute_urls(options[:seed_urls] || ["#{Settings.faux_url}/"])
     @sitemap_urls = coerce_to_absolute_urls(options[:sitemap_urls] || [])
     @domain_allowlist = seed_urls.map { |url| Crawler::Data::URL.parse(url).site }
     @content_extraction = options.fetch(:content_extraction, { enabled: false, mime_types: [] })

--- a/spec/support/faux/faux_crawl.rb
+++ b/spec/support/faux/faux_crawl.rb
@@ -153,9 +153,13 @@ class FauxCrawl # rubocop:disable Metrics/ClassLength
       crawl_id: crawl_id,
       auth: auth,
       user_agent: user_agent,
-      seed_urls: seed_urls,
-      sitemap_urls: sitemap_urls,
-      domain_allowlist: domain_allowlist,
+      domains: [
+        {
+          url: Settings.faux_url,
+          seed_urls: seed_urls,
+          sitemap_urls: sitemap_urls
+        }
+      ],
       content_extraction_enabled: content_extraction.fetch(:enabled),
       content_extraction_mime_types: content_extraction.fetch(:mime_types),
       output_sink: :mock,


### PR DESCRIPTION
### Summary

Currently all configured domains to crawl are included in a single array, `domain_allowlist`. As we move to implement domain-specific configurations, it is necessary to have each domain separated into its own entity. Using this starting point it will be easier to add domain-specific configurations like extraction rules.

The format change is handled entirely within the `Crawler::Api::Config` class. The class object created is still identical to before so this will have no impact on other parts of the codebase. Only the input parameters are changed.

### Changes

- Crawler config.yml now has a `domains` key at base that takes an array. Each item in the array corresponds to 1 domain.
- `domain_allowlist` is now `domains[].url`
- `seed_urls` are now optional, if they aren't provided then the domain's `url` will be used as an entry point.
- `sitemal_urls` are also moved to be within the `domain` array item.
- Updates to tests to support new format

### Example

Crawling 1 site is now configured like this. The entry point will be the `domains[].url` value.
```yaml
domains:
  - url: https://domain1.com
```

Crawling 2 sites can be configured like this. This will;
- crawl 2 domains (`https://domain1.com` and `https://domain2.com`)
- using 3 seed URLs (`https://domain1.com/foo`, `https://domain1.com/bar`, and `https://domain2.com`)

```yaml
domains:
  - url: https://domain1.com
    seed_urls:
      - https://domain1.com/foo
      - https://domain1.com/bar
  - url: https://domain2.com
```