### PR TITLE
Add extraction rules config classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ Open Crawler has a Dockerfile that can be built and run locally.
 
 See [CONFIG.md](docs/CONFIG.md) for in-depth details on Open Crawler configuration files.
 
+### Crawler Document Schema and Mappings
+
+See [DOCUMENT_SCHEMA.md](docs/DOCUMENT_SCHEMA.md) for information regarding the Elasticsearch document schema and mappings.
+
 ### CLI Commands
 
 Open Crawler does not have a graphical user interface.

--- a/config/crawler.yml.example
+++ b/config/crawler.yml.example
@@ -12,19 +12,28 @@
 ## The domain(s) that Crawler will crawl. This is an array. All domains in this
 ##   array will be crawled concurrently by the Crawler with a shared output.
 ##   They are separated to allow for domain-specific configurations.
-##
-##   `domains[].url`           - (Required) The base URL for this domain
-##   `domains[].seed_urls`     - (Optional) The entry point(s) for crawl jobs.
-##								      If this is empty, the `url` will be used.
-##   `domains[].sitemap_urls`  - (Optional) the location(s) of sitemap files
 #
 #domains:
-#  - url: http://localhost:8000
-#    seed_urls:
+#  - url: http://localhost:8000		# The base URL for this domain
+#    seed_urls:						# The entry point(s) for crawl jobs
 #      - http://localhost:8000/foo
 #      - http://localhost:8000/bar
-#    sitemap_urls:
+#    sitemap_urls:					# The location(s) of sitemap files
 #      - http://localhost:8000/sitemap.xml
+#
+#    # An array of content extraction rules
+#    # See docs/CONTENT_EXTRACTION.md for more details on this feature
+#    extraction_rulesets:
+#      - url_filters:
+#          - type: "begins"			# Filter type, can be: begins | ends | contains | regex
+#            pattern: "/blog"		# The pattern for the filter
+#        rules:
+#          - action: "extract"		# Rule action, can be: extract | set
+#            field_name: "author"	# The ES doc field to add the value to
+#            selector: ".author"	# The CSS or XPATH selector
+#            join_as: "array"		# How to concatenate multiple values, can be: array | string
+#            value: "yes"			# The value to use, only applicable if action is `set`
+#            source: "html"			# The source to extract from, can be: html
 #
 ## Where to send the results. Possible values are console, file, or elasticsearch
 #output_sink: elasticsearch

--- a/docs/CONTENT_EXTRACTION.md
+++ b/docs/CONTENT_EXTRACTION.md
@@ -59,27 +59,13 @@ Possible values:
   - If multiple values are found, they will be concatenated according to the `join_as` value
 - `set`
   - Crawler will see if the HTML element configured in `selector` exists or not
-  - If it does exist, Crawler will add the configured `value` to the document using `field_name` as the doc's field name
+  - If one or multiple elements exist, Crawler will add the configured `value` to the document using `field_name` as the doc's field name
   - If it does not exist, Crawler will not add anything to the document
 
 ### `domains[].extraction_rulesets[].rules[].field_name`
 
 The document field name that Crawler will add the extracted content to.
-This can be any string value, as long as it is not one of the following reserved field names.
-
-- `body_content`
-- `domains`
-- `headings`
-- `meta_description`
-- `title`
-- `url`
-- `url_host`
-- `url_path`
-- `url_path_dir1`
-- `url_path_dir2`
-- `url_path_dir3`
-- `url_port`
-- `url_scheme`
+This can be any string value, as long as it is not one of the predefined field names in the [document schema](./DOCUMENT_SCHEMA.md).
 
 ### `domains[].extraction_rulesets[].rules[].selector`
 

--- a/docs/CONTENT_EXTRACTION.md
+++ b/docs/CONTENT_EXTRACTION.md
@@ -1,0 +1,114 @@
+# Content Extraction
+
+Extraction rules enable you to customize how the crawler extracts content from webpages.
+Extraction rules are configured in the Crawler config file.
+These are configured under the `domains[].extraction_rulesets` field.
+
+`domains[].extraction_rulesets` is an array, and it is tied to the `url` within the same `domains` array item.
+If a crawl result's base URL matches the configured `domains[].url`, then Crawler will check if the crawl result's full URL matches any of the URL filters.
+If any of the URL filters match, then Crawler will execute the extraction rules.
+
+## URL Filters
+
+URL filters are an array.
+If a URL matches any of the conditions in this array, then all of the extraction rules will be executed.
+If the URL filter is empty, then the extraction rules will be applied to every crawl result.
+
+### `domains[].extraction_rulesets[].url_filters[].type`
+
+The type of URL filter that will be used.
+
+Possible values:
+
+- `begins`
+  - The beginning of the URL endpoint
+- `ends`
+  - The end of the URL endpoint
+- `contains`
+  - Any value match within the endpoint
+- `regex`
+  - Any regular expression
+
+### `domains[].extraction_rulesets[].url_filters[].pattern`
+
+The pattern the URL filter will follow, dependent on the value for `type`.
+
+The following examples would all work for the URL `http://example.com/blog/help/contact`:
+
+| `type` value | `pattern`  example    |
+|--------------|-----------------------|
+| `begins`     | `/blog`               |
+| `ends`       | `contact`, `/contact` | 
+| `contains`   | `help`, `/help/`      | 
+| `regex`      | `^blog/help/support$` | 
+
+## Rules
+
+Rules are an array.
+If any of the URL filters are true for an endpoint, then Crawler will attempt to execute all of the configured rules in the array.
+
+### `domains[].extraction_rulesets[].rules[].action`
+
+What Crawler should do for this rule.
+
+Possible values:
+
+- `extract` 
+  - Crawler will extract the full HTML element found using the `selector`
+  - Crawler will directly add it to the document using `field_name` as the doc's field name
+  - If multiple values are found, they will be concatenated according to the `join_as` value
+- `set`
+  - Crawler will see if the HTML element configured in `selector` exists or not
+  - If it does exist, Crawler will add the configured `value` to the document using `field_name` as the doc's field name
+  - If it does not exist, Crawler will not add anything to the document
+
+### `domains[].extraction_rulesets[].rules[].field_name`
+
+The document field name that Crawler will add the extracted content to.
+This can be any string value, as long as it is not one of the following reserved field names.
+
+- `body_content`
+- `domains`
+- `headings`
+- `meta_description`
+- `title`
+- `url`
+- `url_host`
+- `url_path`
+- `url_path_dir1`
+- `url_path_dir2`
+- `url_path_dir3`
+- `url_port`
+- `url_scheme`
+
+### `domains[].extraction_rulesets[].rules[].selector`
+
+The selector for finding the content in HTML.
+Can be a CSS selector or an Xpath selector.
+
+There are examples in W3schools for selector syntax:
+- [CSS selectors syntax examples](https://www.w3schools.com/css/css_selectors.asp)
+- [XPath selectors syntax examples](https://www.w3schools.com/xml/xpath_syntax.asp)
+
+You can also refer to the official W3C documentation for more details:
+- [CSS selectors official documentation](https://www.w3.org/TR/selectors-3/) 
+- [XPath selectors official documentation](https://www.w3.org/TR/xpath-31/)
+
+### `domains[].extraction_rulesets[].rules[].join_as`
+
+The method for concatenating multiple values.
+This is only applicable if `action` is `extract`.
+
+Values can be `string` or `array`.
+
+### `domains[].extraction_rulesets[].rules[].value`
+
+The value to be inserted into the document if the selector finds any value.
+This is only applicable if `action` is `set`.
+
+Value can be anything except `null`.
+
+### `domains[].extraction_rulesets[].rules[].source`
+
+The source that Crawler will try to extract content from.
+Currently only `html` is supported.

--- a/docs/DOCUMENT_SCHEMA.md
+++ b/docs/DOCUMENT_SCHEMA.md
@@ -1,0 +1,30 @@
+# Document Schema
+
+Crawler generates Elasticsearch documents from crawl results.
+These documents have a predefined list of fields that are always included.
+
+Crawler does not impose any mappings onto indices that it ingests docs into.
+This means you are free to create whatever mappings you like for an index, so long as you create the mappings _before_ indexing any documents.
+
+If any [content extraction](./CONTENT_EXTRACTION.md) rules have been configured, you can add more fields to the Elasticsearch documents.
+However, the predefined fields can never be changed or overwritten by content extraction rules.
+If you are ingesting onto an index that has custom mappings, be sure that the mappings don't conflict with these predefined fields.
+
+| Field              | Type     |
+|--------------------|----------|
+| `id`               | text     |
+| `body_content`     | text     |
+| `domains`          | text     |
+| `headings`         | text     |
+| `last_crawled_at`  | datetime |
+| `links`            | test     |
+| `meta_description` | text     |
+| `title`            | text     |
+| `url`              | text     |
+| `url_host`         | text     |
+| `url_path`         | text     |
+| `url_path_dir1`    | text     |
+| `url_path_dir2`    | text     |
+| `url_path_dir3`    | text     |
+| `url_port`         | long     |
+| `url_scheme`       | text     |

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -1,0 +1,29 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+
+# frozen_string_literal: true
+
+module Constants
+  # Field names used in every crawl result when creating an ES doc
+  RESERVED_FIELD_NAMES = %w[
+    id
+    body_content
+    domains
+    headings
+    last_crawled_at
+    links
+    meta_description
+    title
+    url
+    url_host
+    url_path
+    url_path_dir1
+    url_path_dir2
+    url_path_dir3
+    url_port
+    url_scheme
+  ].freeze
+end

--- a/lib/crawler/api/config.rb
+++ b/lib/crawler/api/config.rb
@@ -342,7 +342,10 @@ module Crawler
           raise ArgumentError, "Extraction rulesets for #{url} is not an array" unless rulesets.is_a?(Array)
 
           extra_rules = rulesets.flat_map(&:keys) - EXTRACTION_RULES_FIELDS
-          raise ArgumentError, "Unexpected extraction ruleset(s) for #{url}: #{extra_rules.join(', ')}" if extra_rules.any?
+          if extra_rules.any?
+            raise ArgumentError,
+                  "Unexpected extraction ruleset(s) for #{url}: #{extra_rules.join(', ')}"
+          end
 
           extraction_rules[url] = rulesets.map { |ruleset| Crawler::Data::Extraction::Ruleset.new(ruleset) }
         end

--- a/lib/crawler/api/config.rb
+++ b/lib/crawler/api/config.rb
@@ -10,6 +10,7 @@ require 'active_support/core_ext/numeric/bytes'
 
 require_dependency(File.join(__dir__, '..', '..', 'statically_tagged_logger'))
 require_dependency(File.join(__dir__, '..', 'data', 'crawl_result', 'html'))
+require_dependency(File.join(__dir__, '..', 'data', 'extraction', 'ruleset'))
 require_dependency(File.join(__dir__, '..', 'document_mapper'))
 
 java_import java.io.ByteArrayInputStream
@@ -114,8 +115,10 @@ module Crawler
         :sitemap_discovery_disabled, # Enable/disable crawling of sitemaps defined in robots.txt
         :head_requests_enabled, # Fetching HEAD requests before GET requests enabled
 
-        :domains_extraction_rules # Contains domains extraction rules
+        :extraction_rules # Contains domains extraction rules
       ].freeze
+
+      EXTRACTION_RULES_FIELDS = %i[url_filters rules].freeze
 
       # Please note: These defaults are used the `Crawler::HttpUtils::Config` class.
       # Make sure to check those before renaming or removing any defaults.
@@ -171,7 +174,7 @@ module Crawler
         sitemap_discovery_disabled: false,
         head_requests_enabled: false,
 
-        domains_extraction_rules: {}
+        extraction_rules: {}
       }.freeze
 
       # Settings we are not allowed to log due to their sensitive nature
@@ -213,9 +216,9 @@ module Crawler
         configure_robots_txt_service!
         configure_http_header_service!
         configure_sitemap_urls!
+        configure_extraction_rules!
       end
 
-      #---------------------------------------------------------------------------------------------
       def to_s
         formatted_fields = CONFIG_FIELDS.map do |k|
           value = SENSITIVE_FIELDS.include?(k) ? '[redacted]' : public_send(k)
@@ -224,7 +227,6 @@ module Crawler
         "<#{self.class}: #{formatted_fields.join('; ')}>"
       end
 
-      #---------------------------------------------------------------------------------------------
       def validate_param_names!(params)
         extra_params = params.keys - CONFIG_FIELDS
         raise ArgumentError, "Unexpected configuration options: #{extra_params.inspect}" if extra_params.any?
@@ -236,13 +238,11 @@ module Crawler
         end
       end
 
-      #---------------------------------------------------------------------------------------------
       # Generate a new crawl id if needed
       def configure_crawl_id!
         @crawl_id ||= BSON::ObjectId.new.to_s # rubocop:disable Naming/MemoizedInstanceVariableName
       end
 
-      #---------------------------------------------------------------------------------------------
       def confugure_ssl_ca_certificates!
         ssl_ca_certificates.map! do |cert|
           if /BEGIN CERTIFICATE/.match?(cert)
@@ -253,7 +253,6 @@ module Crawler
         end
       end
 
-      #---------------------------------------------------------------------------------------------
       # Parses a PEM-formatted certificate and returns an X509Certificate object for it
       def parse_certificate_string(pem)
         cert_stream = ByteArrayInputStream.new(pem.to_java_bytes)
@@ -263,7 +262,6 @@ module Crawler
         raise ArgumentError, "Error while parsing an SSL certificate: #{e}"
       end
 
-      #---------------------------------------------------------------------------------------------
       # Loads an SSL certificate from disk and returns it as an X509Certificate object
       def load_certificate_from_file(file_name)
         system_logger.debug("Loading SSL certificate: #{file_name.inspect}")
@@ -273,19 +271,20 @@ module Crawler
         raise ArgumentError, "Error while loading an SSL certificate #{file_name.inspect}: #{e}"
       end
 
-      #---------------------------------------------------------------------------------------------
       def configure_domain_allowlist!
         raise ArgumentError, 'Needs at least one domain' unless domains&.any?
 
-        @domain_allowlist = domains.map do |domain|
+        @domain_allowlist, urls = domains.each_with_object([[], []]) do |domain, (allowlist, urls)|
           raise ArgumentError, 'Each domain requires a url' unless domain[:url]
 
           validate_domain!(domain[:url])
-          Crawler::Data::Domain.new(domain[:url])
+          allowlist << Crawler::Data::Domain.new(domain[:url])
+          urls << domain[:url]
         end
+
+        raise ArgumentError, "Main domain urls must be unique, but found [#{urls.join(', ')}]" unless urls == urls.uniq
       end
 
-      #---------------------------------------------------------------------------------------------
       def validate_domain!(domain)
         url = URI.parse(domain)
         raise ArgumentError, "Domain #{domain.inspect} does not have a URL scheme" unless url.scheme
@@ -293,7 +292,6 @@ module Crawler
         raise ArgumentError, "Domain #{domain.inspect} cannot have a path" unless url.path == ''
       end
 
-      #---------------------------------------------------------------------------------------------
       def configure_seed_urls!
         # use the main url if no seed_urls were configured
         seed_urls = domains.flat_map do |domain|
@@ -315,17 +313,14 @@ module Crawler
         end
       end
 
-      #---------------------------------------------------------------------------------------------
       def configure_robots_txt_service!
         @robots_txt_service ||= Crawler::RobotsTxtService.new(user_agent:) # rubocop:disable Naming/MemoizedInstanceVariableName
       end
 
-      #---------------------------------------------------------------------------------------------
       def configure_http_header_service!
         @http_header_service ||= Crawler::HttpHeaderService.new(auth:) # rubocop:disable Naming/MemoizedInstanceVariableName
       end
 
-      #---------------------------------------------------------------------------------------------
       def configure_sitemap_urls!
         # Parse and validate all URLs
         @sitemap_urls = @domains.filter_map do |domain|
@@ -339,7 +334,20 @@ module Crawler
         end
       end
 
-      #---------------------------------------------------------------------------------------------
+      def configure_extraction_rules!
+        @extraction_rules = @domains.each_with_object({}) do |domain, extraction_rules|
+          url = domain[:url]
+          rulesets = domain[:extraction_rulesets].nil? ? [] : domain[:extraction_rulesets]
+
+          raise ArgumentError, "Extraction rulesets for #{url} is not an array" unless rulesets.is_a?(Array)
+
+          extra_rules = rulesets.flat_map(&:keys) - EXTRACTION_RULES_FIELDS
+          raise ArgumentError, "Unexpected extraction ruleset(s) for #{url}: #{extra_rules.join(', ')}" if extra_rules.any?
+
+          extraction_rules[url] = rulesets.map { |ruleset| Crawler::Data::Extraction::Ruleset.new(ruleset) }
+        end
+      end
+
       def configure_logging!(log_level, event_logs_enabled)
         @event_logger = Logger.new($stdout) if event_logs_enabled
 
@@ -351,24 +359,20 @@ module Crawler
         @system_logger = tagged_system_logger.tagged("crawl:#{crawl_id}", crawl_stage)
       end
 
-      #---------------------------------------------------------------------------------------------
       # Returns an event generator used to capture crawl life cycle events
       def events
         @events ||= Crawler::EventGenerator.new(self)
       end
 
-      #---------------------------------------------------------------------------------------------
       # Returns the per-crawl stats object used for aggregating crawl statistics
       def stats
         @stats ||= Crawler::Stats.new
       end
 
-      #---------------------------------------------------------------------------------------------
       def document_mapper
         @document_mapper ||= ::Crawler::DocumentMapper.new(self)
       end
 
-      #---------------------------------------------------------------------------------------------
       # Receives a crawler event object and outputs it into relevant systems
       def output_event(event)
         # Log the event

--- a/lib/crawler/data/extraction/rule.rb
+++ b/lib/crawler/data/extraction/rule.rb
@@ -1,0 +1,90 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+
+# frozen_string_literal: true
+
+module Crawler
+  module Data
+    module Extraction
+      class Rule
+        ACTION_TYPE_EXTRACT ||= 'extract'
+        ACTION_TYPE_SET ||= 'set'
+        ACTIONS ||= [ACTION_TYPE_EXTRACT, ACTION_TYPE_SET].freeze
+        JOINS ||= %w[array string].freeze
+        SOURCES ||= %w[url html].freeze
+        RESERVED_FIELD_NAMES ||= %w[body_content domains headings meta_description title url url_host url_path
+                                  url_path_dir1 url_path_dir2 url_path_dir3 url_port url_scheme].freeze
+
+        attr_reader :action, :field_name, :selector, :join_as, :source, :value
+
+        def initialize(rule)
+          @action = rule[:action]
+          @field_name = rule[:field_name]
+          @selector = rule[:selector]
+          @join_as = rule[:join_as]
+          @source = rule[:source]
+          @value = rule[:value]
+          validate_rule
+        end
+
+        private
+
+        def validate_rule
+          validate_actions
+          validate_field_name
+          validate_join_as
+          validate_source
+          validate_selector
+        end
+
+        def validate_actions
+          unless ACTIONS.include?(@action)
+            raise ArgumentError,
+                  "Extraction rule action `#{@action}` is invalid; value must be one of #{ACTIONS.join(', ')}"
+          end
+
+          return unless @action == ACTION_TYPE_SET && @value.blank?
+
+          raise ArgumentError, "Extraction rule value can't be blank when action is #{ACTION_TYPE_SET}"
+        end
+
+        def validate_field_name
+          raise ArgumentError, "Extraction rule field_name can't be blank" if @field_name.blank?
+
+          return unless RESERVED_FIELD_NAMES.include?(@field_name)
+
+          raise ArgumentError,
+                "Extraction rule field_name can't be a reserved field: #{RESERVED_FIELD_NAMES.join(', ')}"
+        end
+
+        def validate_join_as
+          return if @action == ACTION_TYPE_SET || JOINS.include?(@join_as)
+
+          raise ArgumentError,
+                "Extraction rule join_as `#{@join_as}` is invalid; value must be one of #{JOINS.join(', ')}"
+        end
+
+        def validate_source
+          return if SOURCES.include?(@source)
+
+          raise ArgumentError,
+                "Extraction rule source `#{@source}` is invalid; value must be one of #{SOURCES.join(', ')}"
+        end
+
+        def validate_selector
+          raise ArgumentError, "Extraction rule selector can't be blank" if @selector.blank?
+
+          # NOTE: expand for other sources when added (e.g. url)
+          begin
+            Nokogiri::HTML::DocumentFragment.parse('<a></a>').search(@selector)
+          rescue Nokogiri::CSS::SyntaxError, Nokogiri::XML::XPath::SyntaxError => e
+            raise ArgumentError, "Extraction rule selector `#{@selector}` is not valid: #{e.message}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crawler/data/extraction/rule.rb
+++ b/lib/crawler/data/extraction/rule.rb
@@ -10,12 +10,12 @@ module Crawler
   module Data
     module Extraction
       class Rule
-        ACTION_TYPE_EXTRACT ||= 'extract'
-        ACTION_TYPE_SET ||= 'set'
-        ACTIONS ||= [ACTION_TYPE_EXTRACT, ACTION_TYPE_SET].freeze
-        JOINS ||= %w[array string].freeze
-        SOURCES ||= %w[url html].freeze
-        RESERVED_FIELD_NAMES ||= %w[body_content domains headings meta_description title url url_host url_path
+        ACTION_TYPE_EXTRACT = 'extract'
+        ACTION_TYPE_SET = 'set'
+        ACTIONS = [ACTION_TYPE_EXTRACT, ACTION_TYPE_SET].freeze
+        JOINS = %w[array string].freeze
+        SOURCES = %w[url html].freeze
+        RESERVED_FIELD_NAMES = %w[body_content domains headings meta_description title url url_host url_path
                                   url_path_dir1 url_path_dir2 url_path_dir3 url_port url_scheme].freeze
 
         attr_reader :action, :field_name, :selector, :join_as, :source, :value
@@ -46,13 +46,15 @@ module Crawler
                   "Extraction rule action `#{@action}` is invalid; value must be one of #{ACTIONS.join(', ')}"
           end
 
-          return unless @action == ACTION_TYPE_SET && @value.blank?
+          return unless @action == ACTION_TYPE_SET && @value.nil?
 
-          raise ArgumentError, "Extraction rule value can't be blank when action is #{ACTION_TYPE_SET}"
+          raise ArgumentError, "Extraction rule value can't be blank when action is `#{ACTION_TYPE_SET}`"
         end
 
         def validate_field_name
-          raise ArgumentError, "Extraction rule field_name can't be blank" if @field_name.blank?
+          raise ArgumentError, 'Extraction rule field_name must be a string' unless @field_name.is_a?(String)
+
+          raise ArgumentError, "Extraction rule field_name can't be blank" if @field_name == ''
 
           return unless RESERVED_FIELD_NAMES.include?(@field_name)
 

--- a/lib/crawler/data/extraction/rule.rb
+++ b/lib/crawler/data/extraction/rule.rb
@@ -6,6 +6,8 @@
 
 # frozen_string_literal: true
 
+require_dependency(File.join(__dir__, '..', '..', '..', 'constants'))
+
 module Crawler
   module Data
     module Extraction
@@ -15,8 +17,6 @@ module Crawler
         ACTIONS = [ACTION_TYPE_EXTRACT, ACTION_TYPE_SET].freeze
         JOINS = %w[array string].freeze
         SOURCES = %w[url html].freeze
-        RESERVED_FIELD_NAMES = %w[body_content domains headings meta_description title url url_host url_path
-                                  url_path_dir1 url_path_dir2 url_path_dir3 url_port url_scheme].freeze
 
         attr_reader :action, :field_name, :selector, :join_as, :source, :value
 
@@ -56,10 +56,10 @@ module Crawler
 
           raise ArgumentError, "Extraction rule field_name can't be blank" if @field_name == ''
 
-          return unless RESERVED_FIELD_NAMES.include?(@field_name)
+          return unless Constants::RESERVED_FIELD_NAMES.include?(@field_name)
 
           raise ArgumentError,
-                "Extraction rule field_name can't be a reserved field: #{RESERVED_FIELD_NAMES.join(', ')}"
+                "Extraction rule field_name can't be a reserved field: #{Constants::RESERVED_FIELD_NAMES.join(', ')}"
         end
 
         def validate_join_as

--- a/lib/crawler/data/extraction/ruleset.rb
+++ b/lib/crawler/data/extraction/ruleset.rb
@@ -1,0 +1,62 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+
+# frozen_string_literal: true
+
+require_relative 'rule'
+require_relative 'url_filter'
+
+module Crawler
+  module Data
+    module Extraction
+      class Ruleset
+        def initialize(ruleset)
+          @ruleset = ruleset
+          validate_ruleset
+
+          # initialize these after validating they are arrays
+          rules
+          url_filters
+        end
+
+        def rules
+          @rules ||=
+            if @ruleset[:rules]&.any?
+              @ruleset[:rules].map do |rule|
+                Crawler::Data::Extraction::Rule.new(rule)
+              end
+            else
+              []
+            end
+        end
+
+        def url_filters
+          @url_filters ||=
+            if @ruleset[:url_filters]&.any?
+              @ruleset[:url_filters].map do |filter|
+                Crawler::Data::Extraction::UrlFilter.new(filter)
+              end
+            else
+              []
+            end
+        end
+
+        private
+
+        def validate_ruleset
+          puts(@ruleset)
+          if @ruleset[:rules] && !@ruleset[:rules].is_a?(Array)
+            raise ArgumentError, 'Extraction ruleset rules must be an array'
+          end
+
+          return unless @ruleset[:url_filters] && !@ruleset[:url_filters].is_a?(Array)
+
+          raise ArgumentError, 'Extraction ruleset url_filters must be an array'
+        end
+      end
+    end
+  end
+end

--- a/lib/crawler/data/extraction/ruleset.rb
+++ b/lib/crawler/data/extraction/ruleset.rb
@@ -47,12 +47,11 @@ module Crawler
         private
 
         def validate_ruleset
-          puts(@ruleset)
-          if @ruleset[:rules] && !@ruleset[:rules].is_a?(Array)
+          if !@ruleset[:rules].nil? && !@ruleset[:rules].is_a?(Array)
             raise ArgumentError, 'Extraction ruleset rules must be an array'
           end
 
-          return unless @ruleset[:url_filters] && !@ruleset[:url_filters].is_a?(Array)
+          return unless !@ruleset[:url_filters].nil? && !@ruleset[:url_filters].is_a?(Array)
 
           raise ArgumentError, 'Extraction ruleset url_filters must be an array'
         end

--- a/lib/crawler/data/extraction/ruleset.rb
+++ b/lib/crawler/data/extraction/ruleset.rb
@@ -6,8 +6,8 @@
 
 # frozen_string_literal: true
 
-require_relative 'rule'
-require_relative 'url_filter'
+require_dependency(File.join(__dir__, 'rule'))
+require_dependency(File.join(__dir__, 'url_filter'))
 
 module Crawler
   module Data

--- a/lib/crawler/data/extraction/url_filter.rb
+++ b/lib/crawler/data/extraction/url_filter.rb
@@ -1,0 +1,53 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+
+# frozen_string_literal: true
+
+module Crawler
+  module Data
+    module Extraction
+      class UrlFilter
+        REGEX_TIMEOUT ||= 0.5 # seconds
+        TYPES ||= %w[begins ends contains regex].freeze
+
+        attr_reader :type, :pattern
+
+        def initialize(url_filter)
+          @type = url_filter[:type]
+          @pattern = url_filter[:pattern]
+          validate_url_filter
+        end
+
+        private
+
+        def validate_url_filter
+          unless TYPES.include?(@type)
+            raise ArgumentError, "Extraction ruleset url_filter type must be one of #{TYPES.join(', ')}"
+          end
+
+          raise ArgumentError, 'URL pattern can not be blank' if @pattern.blank?
+
+          case @type
+          when 'begins'
+            raise ArgumentError, 'pattern must begin with a slash (/)' unless @pattern.start_with?('/')
+          when 'regex'
+            begin
+              _ = Regexp.new(@pattern)
+            rescue RegexpError => e
+              raise ArgumentError, "regular expression is invalid: #{e.message}"
+            end
+          end
+        end
+
+        def url_match?(url)
+          Timeout.timeout(REGEX_TIMEOUT) do
+            @url_pattern.match?(url.to_s)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/crawler/data/extraction/url_filter.rb
+++ b/lib/crawler/data/extraction/url_filter.rb
@@ -10,8 +10,8 @@ module Crawler
   module Data
     module Extraction
       class UrlFilter
-        REGEX_TIMEOUT ||= 0.5 # seconds
-        TYPES ||= %w[begins ends contains regex].freeze
+        REGEX_TIMEOUT = 0.5 # seconds
+        TYPES = %w[begins ends contains regex].freeze
 
         attr_reader :type, :pattern
 
@@ -25,21 +25,26 @@ module Crawler
 
         def validate_url_filter
           unless TYPES.include?(@type)
-            raise ArgumentError, "Extraction ruleset url_filter type must be one of #{TYPES.join(', ')}"
+            raise ArgumentError,
+                  "Extraction ruleset url_filter `#{@type}` is invalid; value must be one of #{TYPES.join(', ')}"
           end
 
-          raise ArgumentError, 'URL pattern can not be blank' if @pattern.blank?
+          raise ArgumentError, 'Extraction ruleset url_filter pattern can not be blank' if @pattern.blank?
 
           case @type
           when 'begins'
-            raise ArgumentError, 'pattern must begin with a slash (/)' unless @pattern.start_with?('/')
-          when 'regex'
-            begin
-              _ = Regexp.new(@pattern)
-            rescue RegexpError => e
-              raise ArgumentError, "regular expression is invalid: #{e.message}"
+            unless @pattern.start_with?('/')
+              raise ArgumentError,
+                    'Extraction ruleset url_filter pattern must begin with a slash (/) if type is `begins`'
             end
+          when 'regex' then validate_regex
           end
+        end
+
+        def validate_regex
+          _ = Regexp.new(@pattern)
+        rescue RegexpError => e
+          raise ArgumentError, "Extraction ruleset url_filter pattern regex is invalid: #{e.message}"
         end
 
         def url_match?(url)

--- a/spec/lib/crawler/data/extraction/rule_spec.rb
+++ b/spec/lib/crawler/data/extraction/rule_spec.rb
@@ -1,0 +1,161 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+
+# frozen_string_literal: true
+
+RSpec.describe(Crawler::Data::Extraction::Rule) do
+  let(:action) { 'extract' }
+  let(:field_name) { 'foo' }
+  let(:selector) { '.foo' }
+  let(:join_as) { 'array' }
+  let(:source) { 'html' }
+
+  let(:rule_input) { { action:, field_name:, selector:, join_as:, source: } }
+
+  describe '#initialize' do
+    it 'initializes with a valid rule' do
+      rule = described_class.new(rule_input)
+
+      expect(rule.action).to eq(action)
+      expect(rule.field_name).to eq(field_name)
+      expect(rule.selector).to eq(selector)
+      expect(rule.join_as).to eq(join_as)
+      expect(rule.source).to eq(source)
+    end
+
+    context 'when action is invalid' do
+      let(:action) { 'invalid' }
+      let(:expected_actions) { Crawler::Data::Extraction::Rule::ACTIONS.join(', ') }
+      it 'raises an error' do
+        expect do
+          described_class.new(rule_input)
+        end.to raise_error(
+          ArgumentError,
+          "Extraction rule action `#{action}` is invalid; value must be one of #{expected_actions}"
+        )
+      end
+    end
+
+    context 'when action is `set`' do
+      let(:action) { 'set' }
+
+      before :each do
+        rule_input[:value] = value
+      end
+
+      [0, 1, '', 'foo', [], %w[an array], { an: 'object?' }, true, false].each do |valid_value|
+        let(:value) { valid_value }
+
+        it 'assigns a value' do
+          rule = described_class.new(rule_input)
+          expect(rule.action).to eq('set')
+          expect(rule.value).to eq(value)
+        end
+      end
+    end
+
+    context 'when action is `set` and value is nil' do
+      let(:action) { 'set' }
+      let(:value) { nil }
+
+      it 'raises an error' do
+        expect do
+          described_class.new(rule_input)
+        end.to raise_error(
+          ArgumentError,
+          "Extraction rule value can't be blank when action is `set`"
+        )
+      end
+    end
+
+    context 'when field_name is not a string' do
+      [nil, 0, 1, [], %w[an array], { an: 'object?' }, true, false].each do |invalid_field_name|
+        let(:field_name) { invalid_field_name }
+
+        it 'raises an error' do
+          expect do
+            described_class.new(rule_input)
+          end.to raise_error(
+            ArgumentError,
+            'Extraction rule field_name must be a string'
+          )
+        end
+      end
+    end
+
+    context 'when field_name is empty' do
+      let(:field_name) { '' }
+
+      it 'raises an error' do
+        expect do
+          described_class.new(rule_input)
+        end.to raise_error(
+          ArgumentError,
+          "Extraction rule field_name can't be blank"
+        )
+      end
+    end
+
+    context 'when field_name is reserved' do
+      let(:reserved_field_names) { Crawler::Data::Extraction::Rule::RESERVED_FIELD_NAMES }
+
+      # can't use the above variable for this as it's used in the context block
+      Crawler::Data::Extraction::Rule::RESERVED_FIELD_NAMES.each do |reserved_field_name|
+        let(:field_name) { reserved_field_name }
+
+        it 'raises an error' do
+          expect do
+            described_class.new(rule_input)
+          end.to raise_error(
+            ArgumentError,
+            "Extraction rule field_name can't be a reserved field: #{reserved_field_names.join(', ')}"
+          )
+        end
+      end
+    end
+
+    context 'when join_as is invalid' do
+      let(:valid_joins) { Crawler::Data::Extraction::Rule::JOINS.join(', ') }
+      let(:join_as) { 'concatenate?' } # invalid
+
+      it 'raises an error' do
+        expect do
+          described_class.new(rule_input)
+        end.to raise_error(
+          ArgumentError,
+          "Extraction rule join_as `#{join_as}` is invalid; value must be one of #{valid_joins}"
+        )
+      end
+    end
+
+    context 'when source is invalid' do
+      let(:valid_sources) { Crawler::Data::Extraction::Rule::SOURCES.join(', ') }
+      let(:source) { 'xml' } # invalid
+
+      it 'raises an error' do
+        expect do
+          described_class.new(rule_input)
+        end.to raise_error(
+          ArgumentError,
+          "Extraction rule source `#{source}` is invalid; value must be one of #{valid_sources}"
+        )
+      end
+    end
+
+    context 'when selector is invalid' do
+      let(:selector) { '.#class-or-id' }
+
+      it 'raises an error' do
+        expect do
+          described_class.new(rule_input)
+        end.to raise_error(
+          ArgumentError,
+          /^Extraction rule selector `\.#class-or-id` is not valid: */
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/crawler/data/extraction/rule_spec.rb
+++ b/spec/lib/crawler/data/extraction/rule_spec.rb
@@ -100,10 +100,10 @@ RSpec.describe(Crawler::Data::Extraction::Rule) do
     end
 
     context 'when field_name is reserved' do
-      let(:reserved_field_names) { Crawler::Data::Extraction::Rule::RESERVED_FIELD_NAMES }
+      let(:reserved_field_names) { Constants::RESERVED_FIELD_NAMES }
 
       # can't use the above variable for this as it's used in the context block
-      Crawler::Data::Extraction::Rule::RESERVED_FIELD_NAMES.each do |reserved_field_name|
+      Constants::RESERVED_FIELD_NAMES.each do |reserved_field_name|
         let(:field_name) { reserved_field_name }
 
         it 'raises an error' do

--- a/spec/lib/crawler/data/extraction/ruleset_spec.rb
+++ b/spec/lib/crawler/data/extraction/ruleset_spec.rb
@@ -1,0 +1,75 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+
+# frozen_string_literal: true
+
+RSpec.describe(Crawler::Data::Extraction::Ruleset) do
+  let(:url_filters) do
+    [
+      { type: 'begins', pattern: '/blog' },
+      { type: 'regex', pattern: '/blog/*' }
+    ]
+  end
+  let(:rules) do
+    [
+      { action: 'extract', field_name: 'foo', selector: '.foo', join_as: 'array', source: 'html' },
+      { action: 'set', field_name: 'bar', selector: '.bar', value: 'Bar exists!', source: 'html' }
+    ]
+  end
+  let(:ruleset_input) do
+    {
+      rules:,
+      url_filters:
+    }
+  end
+
+  describe '#initialize' do
+    it 'initializes with a valid ruleset' do
+      ruleset = described_class.new(ruleset_input)
+
+      expect(ruleset.rules.size).to eq(2)
+      expect(ruleset.rules.map(&:action)).to match_array(%w[extract set])
+
+      expect(ruleset.url_filters.size).to eq(2)
+      expect(ruleset.url_filters.map(&:type)).to eq(%w[begins regex])
+    end
+
+    context 'when rules and url_filters are empty' do
+      [[], nil].each do |empty_param|
+        let(:url_filters) { empty_param }
+        let(:rules) { empty_param }
+        it 'initializes with empty arrays' do
+          ruleset = described_class.new(ruleset_input)
+
+          expect(ruleset.rules).to eq([])
+          expect(ruleset.url_filters).to eq([])
+        end
+      end
+    end
+
+    context 'when rules is an invalid type' do
+      ['', 'a string?', 0, 1, true, false, { foo: 'bar' }].each do |invalid_rule|
+        let(:rules) { invalid_rule }
+        it 'raises an ArgumentError' do
+          expect do
+            described_class.new(ruleset_input)
+          end.to raise_error(ArgumentError, 'Extraction ruleset rules must be an array')
+        end
+      end
+    end
+
+    context 'when url_filters is an invalid type' do
+      ['', 'a string?', 0, 1, true, false, { foo: 'bar' }].each do |invalid_filter|
+        let(:url_filters) { invalid_filter }
+        it 'raises an ArgumentError' do
+          expect do
+            described_class.new(ruleset_input)
+          end.to raise_error(ArgumentError, 'Extraction ruleset url_filters must be an array')
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/crawler/data/extraction/url_filter_spec.rb
+++ b/spec/lib/crawler/data/extraction/url_filter_spec.rb
@@ -1,0 +1,77 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+
+# frozen_string_literal: true
+
+RSpec.describe(Crawler::Data::Extraction::UrlFilter) do
+  let(:type) { 'begins' }
+  let(:pattern) { '/foo' }
+
+  let(:filter_input) { { type:, pattern: } }
+
+  describe '#initialize' do
+    it 'initializes with a valid url filter' do
+      url_filter = described_class.new(filter_input)
+
+      expect(url_filter.type).to eq(type)
+      expect(url_filter.pattern).to eq(pattern)
+    end
+
+    context 'when type is invalid' do
+      let(:valid_types) { Crawler::Data::Extraction::UrlFilter::TYPES.join(', ') }
+      let(:type) { 'invalid' }
+
+      it 'raises an error' do
+        expect do
+          described_class.new(filter_input)
+        end.to raise_error(
+          ArgumentError,
+          "Extraction ruleset url_filter `#{type}` is invalid; value must be one of #{valid_types}"
+        )
+      end
+    end
+
+    context 'when pattern is blank' do
+      let(:pattern) { '' }
+
+      it 'raises an error' do
+        expect do
+          described_class.new(filter_input)
+        end.to raise_error(
+          ArgumentError,
+          'Extraction ruleset url_filter pattern can not be blank'
+        )
+      end
+    end
+
+    context 'when type is `begins` and pattern is invalid' do
+      let(:pattern) { 'invalid/pattern' }
+
+      it 'raises an error' do
+        expect do
+          described_class.new(filter_input)
+        end.to raise_error(
+          ArgumentError,
+          'Extraction ruleset url_filter pattern must begin with a slash (/) if type is `begins`'
+        )
+      end
+    end
+
+    context 'when type is `regex` and pattern is invalid' do
+      let(:type) { 'regex' } # broken regex
+      let(:pattern) { '[a-z' } # broken regex
+
+      it 'raises an error' do
+        expect do
+          described_class.new(filter_input)
+        end.to raise_error(
+          ArgumentError,
+          /^Extraction ruleset url_filter pattern regex is invalid: /
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is the first step in enabling CSS, XPATH and URL content extraction.

- Add classes for managing extraction rules config
- Set up per-URL content extraction config on startup
- Add documentation
