### PR TITLE
Change field body_content to body

### DIFF
--- a/docs/DOCUMENT_SCHEMA.md
+++ b/docs/DOCUMENT_SCHEMA.md
@@ -13,7 +13,7 @@ If you are ingesting onto an index that has custom mappings, be sure that the ma
 | Field              | Type     |
 |--------------------|----------|
 | `id`               | text     |
-| `body_content`     | text     |
+| `body`             | text     |
 | `domains`          | text     |
 | `headings`         | text     |
 | `last_crawled_at`  | datetime |

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -10,7 +10,7 @@ module Constants
   # Field names used in every crawl result when creating an ES doc
   RESERVED_FIELD_NAMES = %w[
     id
-    body_content
+    body
     domains
     headings
     last_crawled_at

--- a/lib/crawler/document_mapper.rb
+++ b/lib/crawler/document_mapper.rb
@@ -38,7 +38,7 @@ module Crawler
     def document_fields(crawl_result) # rubocop:disable Metrics/AbcSize
       remove_empty_values(
         'title' => crawl_result.document_title(limit: config.max_title_size),
-        'body_content' => crawl_result.document_body(limit: config.max_body_size),
+        'body' => crawl_result.document_body(limit: config.max_body_size),
         'meta_keywords' => crawl_result.meta_keywords(limit: config.max_keywords_size),
         'meta_description' => crawl_result.meta_description(limit: config.max_description_size),
         'links' => crawl_result.links(limit: config.max_indexed_links_count),

--- a/spec/lib/crawler/output_sink/elasticsearch_spec.rb
+++ b/spec/lib/crawler/output_sink/elasticsearch_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
       let(:expected_doc) do
         {
           id: crawl_result.url_hash,
-          body_content: 'some page',
+          body: 'some page',
           _reduce_whitespace: true,
           _run_ml_inference: true,
           _extract_binary_content: true
@@ -214,7 +214,7 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
       let(:big_crawl_result) do
         FactoryBot.build(:html_crawl_result, url: 'http://example.com/big', content: 'pretend this string is big')
       end
-      let(:big_doc) { { id: big_crawl_result.url_hash, body_content: 'pretend this string is big' }.stringify_keys }
+      let(:big_doc) { { id: big_crawl_result.url_hash, body: 'pretend this string is big' }.stringify_keys }
 
       before(:each) do
         allow(bulk_queue).to receive(:will_fit?).and_return(false)
@@ -238,8 +238,8 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
       let(:crawl_result_two) do
         FactoryBot.build(:html_crawl_result, url: 'http://example.com/two', content: 'work work!')
       end
-      let(:doc_one) { { id: crawl_result_one.url_hash, body_content: 'hoho, haha!' }.stringify_keys }
-      let(:doc_two) { { id: crawl_result_two.url_hash, body_content: 'work work!' }.stringify_keys }
+      let(:doc_one) { { id: crawl_result_one.url_hash, body: 'hoho, haha!' }.stringify_keys }
+      let(:doc_two) { { id: crawl_result_two.url_hash, body: 'work work!' }.stringify_keys }
 
       before(:each) do
         # emulated behaviour is:

--- a/spec/lib/utility/es_client_spec.rb
+++ b/spec/lib/utility/es_client_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe(Utility::EsClient) do
       {
         body: [
           { index: { _index: 'my_index', _id: '123' } },
-          { id: '123', title: 'Foo', body_content: 'bar' }
+          { id: '123', title: 'Foo', body: 'bar' }
         ]
       }
     end


### PR DESCRIPTION
### Closes https://github.com/elastic/crawler/issues/48

Rename the `body_content` field on indexed docs to `body` to keep it in-line with Connectors doc format.