### PR TITLE
Add URL content extraction

### DIFF
--- a/config/crawler.yml.example
+++ b/config/crawler.yml.example
@@ -30,10 +30,10 @@
 #        rules:
 #          - action: "extract"		# Rule action, can be: extract | set
 #            field_name: "author"	# The ES doc field to add the value to
-#            selector: ".author"	# The CSS or XPATH selector
+#            selector: ".author"	# CSS or XPATH selector if source is `html`, regexp if source is `url`
 #            join_as: "array"		# How to concatenate multiple values, can be: array | string
 #            value: "yes"			# The value to use, only applicable if action is `set`
-#            source: "html"			# The source to extract from, can be: html
+#            source: "html"			# The source to extract from, can be: html | url
 #
 ## Where to send the results. Possible values are console, file, or elasticsearch
 #output_sink: elasticsearch

--- a/docs/CONTENT_EXTRACTION.md
+++ b/docs/CONTENT_EXTRACTION.md
@@ -70,7 +70,10 @@ This can be any string value, as long as it is not one of the predefined field n
 ### `domains[].extraction_rulesets[].rules[].selector`
 
 The selector for finding the content in HTML.
-Can be a CSS selector or an Xpath selector.
+
+#### Selectors for `html` sources
+
+If `source` is `html`, this can be a CSS selector or an Xpath selector.
 
 There are examples in W3schools for selector syntax:
 - [CSS selectors syntax examples](https://www.w3schools.com/css/css_selectors.asp)
@@ -79,6 +82,18 @@ There are examples in W3schools for selector syntax:
 You can also refer to the official W3C documentation for more details:
 - [CSS selectors official documentation](https://www.w3.org/TR/selectors-3/) 
 - [XPath selectors official documentation](https://www.w3.org/TR/xpath-31/)
+
+#### Selectors for `url` sources
+
+If `source` is `url`, this must be a regular expression (regexp).
+We recommend using capturing groups to explicitly indicate which part of the regular expression needs to stored as a content field.
+
+Here are some examples:
+
+| String                                        | Regex                                       | Match result       | Match group (final result) |
+|-----------------------------------------------|---------------------------------------------|--------------------|----------------------------|
+| `https://example.org/posts/2023/01/20/post-1` | `posts\/([0-9]{4})`                         | `posts/2023`       | `2023`                     |
+| `https://example.org/posts/2023/01/20/post-1` | `posts\/([0-9]{4})\/([0-9]{2})\/([0-9]{2})` | `posts/2023/01/20` | `[2023, 01, 20]`           |
 
 ### `domains[].extraction_rulesets[].rules[].join_as`
 
@@ -97,4 +112,4 @@ Value can be anything except `null`.
 ### `domains[].extraction_rulesets[].rules[].source`
 
 The source that Crawler will try to extract content from.
-Currently only `html` is supported.
+Currently only `html` or `url` is supported.

--- a/lib/crawler/content_engine/extractor.rb
+++ b/lib/crawler/content_engine/extractor.rb
@@ -9,6 +9,8 @@
 module Crawler
   module ContentEngine
     module Extractor
+      REGEX_TIMEOUT = 0.5 # seconds
+
       def self.extract(rulesets, crawl_result)
         fields = {}
 
@@ -39,12 +41,11 @@ module Crawler
       end
 
       def self.extract_from_crawl_result(rule, crawl_result)
-        # NOTE: re-enable when we support URL extraction
-        # if rule[:source_type] == Crawler::Data::Extraction::Rule::SOURCES_URL
-        #   Timeout.timeout(REGEX_TIMEOUT) do
-        #     return crawl_result.url.extract_by_regexp(Regexp.new(rule[:selector]))
-        #   end
-        # end
+        if rule.source == Crawler::Data::Extraction::Rule::SOURCES_URL
+          Timeout.timeout(REGEX_TIMEOUT) do
+            return crawl_result.url.extract_by_regexp(Regexp.new(rule.selector))
+          end
+        end
 
         return [] unless crawl_result.is_a?(Crawler::Data::CrawlResult::HTML)
 

--- a/lib/crawler/data/extraction/rule.rb
+++ b/lib/crawler/data/extraction/rule.rb
@@ -85,11 +85,19 @@ module Crawler
         def validate_selector
           raise ArgumentError, "Extraction rule selector can't be blank" if @selector.blank?
 
-          # NOTE: expand for other sources when added (e.g. url)
-          begin
-            Nokogiri::HTML::DocumentFragment.parse('<a></a>').search(@selector)
-          rescue Nokogiri::CSS::SyntaxError, Nokogiri::XML::XPath::SyntaxError => e
-            raise ArgumentError, "Extraction rule selector `#{@selector}` is not valid: #{e.message}"
+          if @source == SOURCES_HTML
+            begin
+              Nokogiri::HTML::DocumentFragment.parse('<a></a>').search(@selector)
+            rescue Nokogiri::CSS::SyntaxError, Nokogiri::XML::XPath::SyntaxError => e
+              raise ArgumentError, "Extraction rule selector `#{@selector}` is not a valid HTML selector: #{e.message}"
+            end
+          else
+            begin
+              Regexp.new(@selector)
+            rescue RegexpError => e
+              raise ArgumentError,
+                    "Extraction rule selector `#{@selector}` is not a valid regular expression: #{e.message}"
+            end
           end
         end
       end

--- a/lib/crawler/data/url.rb
+++ b/lib/crawler/data/url.rb
@@ -79,11 +79,11 @@ module Crawler
         match_data = regexp.match(normalized_url)
         return [] unless match_data
 
-        # return capture is regex groups are used
+        # return capture if regex groups are used
         captures = match_data.captures
         return captures unless captures.empty?
 
-        # return a successulf match as a single element array
+        # return a successful match as a single element array
         match_data.to_a
       end
     end

--- a/spec/lib/crawler/data/extraction/rule_spec.rb
+++ b/spec/lib/crawler/data/extraction/rule_spec.rb
@@ -153,7 +153,32 @@ RSpec.describe(Crawler::Data::Extraction::Rule) do
           described_class.new(rule_input)
         end.to raise_error(
           ArgumentError,
-          /^Extraction rule selector `\.#class-or-id` is not valid: */
+          /^Extraction rule selector `\.#class-or-id` is not a valid HTML selector: */
+        )
+      end
+    end
+
+    context 'when source is `url` and regex is valid' do
+      let(:source) { 'url' }
+      let(:selector) { '[0-9]' }
+
+      it 'should assign values' do
+        rule = described_class.new(rule_input)
+        expect(rule.source).to eq(source)
+        expect(rule.selector).to eq(selector)
+      end
+    end
+
+    context 'when source is `url` and selector regex is invalid' do
+      let(:source) { 'url' }
+      let(:selector) { '[' }
+
+      it 'raises an error' do
+        expect do
+          described_class.new(rule_input)
+        end.to raise_error(
+          ArgumentError,
+          /^Extraction rule selector `\[` is not a valid regular expression: */
         )
       end
     end


### PR DESCRIPTION
### Summary

Add support for extracting content from the URLs of crawl results.
These settings are configured in the crawler config yaml file. URL content extraction is done through regular expressions.

### Release notes

URL content extraction is now supported. See `docs/CONTENT_EXTRACTION.md` for details.