### PR TITLE
Refactor ES classes

### DIFF
--- a/lib/crawler/output_sink/elasticsearch.rb
+++ b/lib/crawler/output_sink/elasticsearch.rb
@@ -7,8 +7,8 @@
 # frozen_string_literal: true
 
 require_dependency File.join(__dir__, 'base')
-require_dependency File.join(__dir__, '..', '..', 'utility', 'es_client')
-require_dependency File.join(__dir__, '..', '..', 'utility', 'bulk_queue')
+require_dependency File.join(__dir__, '..', '..', 'es', 'client')
+require_dependency File.join(__dir__, '..', '..', 'es', 'bulk_queue')
 require_dependency File.join(__dir__, '..', '..', 'errors')
 
 module Crawler
@@ -87,7 +87,7 @@ module Crawler
           client.bulk(body:, pipeline:) # TODO: parse response
           system_logger.info("Successfully indexed #{indexing_docs_count} docs.")
           reset_ingestion_stats(true)
-        rescue Utility::EsClient::IndexingFailedError => e
+        rescue ES::Client::IndexingFailedError => e
           system_logger.warn("Bulk index failed: #{e}")
           reset_ingestion_stats(false)
         rescue StandardError => e
@@ -101,7 +101,7 @@ module Crawler
       end
 
       def operation_queue
-        @operation_queue ||= Utility::BulkQueue.new(
+        @operation_queue ||= ES::BulkQueue.new(
           es_config.dig(:bulk_api, :max_items),
           es_config.dig(:bulk_api, :max_size_bytes),
           system_logger
@@ -113,7 +113,7 @@ module Crawler
       end
 
       def client
-        @client ||= Utility::EsClient.new(es_config, system_logger, Crawler.version, crawl_id)
+        @client ||= ES::Client.new(es_config, system_logger, Crawler.version, crawl_id)
       end
 
       def index_name

--- a/lib/es/bulk_queue.rb
+++ b/lib/es/bulk_queue.rb
@@ -10,7 +10,7 @@ require 'elasticsearch/api'
 
 require_dependency File.join(__dir__, '..', 'errors')
 
-module Utility
+module ES
   class BulkQueue
     # Maximum number of operations in BULK Elasticsearch operation that will ingest the data
     DEFAULT_OP_COUNT_THRESHOLD = 100

--- a/lib/es/client.rb
+++ b/lib/es/client.rb
@@ -9,8 +9,8 @@
 require 'fileutils'
 require 'elasticsearch'
 
-module Utility
-  class EsClient < ::Elasticsearch::Client
+module ES
+  class Client < ::Elasticsearch::Client
     USER_AGENT = 'elastic-web-crawler-'
     MAX_RETRIES = 3
     REQUEST_TIMEOUT = 10 # seconds

--- a/spec/lib/crawler/output_sink/elasticsearch_spec.rb
+++ b/spec/lib/crawler/output_sink/elasticsearch_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
   let(:deleted_id) { 25 }
 
   before(:each) do
-    allow(Utility::EsClient).to receive(:new).and_return(es_client)
-    allow(Utility::BulkQueue).to receive(:new).and_return(bulk_queue)
+    allow(ES::Client).to receive(:new).and_return(es_client)
+    allow(ES::BulkQueue).to receive(:new).and_return(bulk_queue)
     allow(config).to receive(:system_logger).and_return(system_logger)
 
     allow(es_client).to receive(:bulk)
@@ -301,7 +301,7 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
 
     context('when an error occurs during indexing') do
       before(:each) do
-        allow(es_client).to receive(:bulk).and_raise(Utility::EsClient::IndexingFailedError.new('BOOM'))
+        allow(es_client).to receive(:bulk).and_raise(ES::Client::IndexingFailedError.new('BOOM'))
       end
 
       it 'logs error' do
@@ -382,7 +382,7 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
 
         before(:each) do
           allow(bulk_queue).to receive(:bytesize).and_return(serialized_object.bytesize)
-          allow(es_client).to receive(:bulk).and_raise(Utility::EsClient::IndexingFailedError.new('BOOM'))
+          allow(es_client).to receive(:bulk).and_raise(ES::Client::IndexingFailedError.new('BOOM'))
 
           document_count.times.each do |x|
             subject.write(FactoryBot.build(:html_crawl_result, url: "http://real.com/#{x}"))

--- a/spec/lib/es/bulk_queue_spec.rb
+++ b/spec/lib/es/bulk_queue_spec.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-RSpec.describe(Utility::BulkQueue) do
+RSpec.describe(ES::BulkQueue) do
   let(:subject) { described_class.new(count_threshold, size_threshold, system_logger) }
   let(:system_logger) { double }
   let(:count_threshold) { 50 }

--- a/spec/lib/es/client_spec.rb
+++ b/spec/lib/es/client_spec.rb
@@ -8,7 +8,7 @@
 
 require 'elasticsearch'
 
-RSpec.describe(Utility::EsClient) do
+RSpec.describe(ES::Client) do
   let(:system_logger) { double }
   let(:host) { 'http://notreallyaserver' }
   let(:port) { '9200' }
@@ -143,7 +143,7 @@ RSpec.describe(Utility::EsClient) do
       let(:file_double) { double('File', puts: nil, close: nil) }
 
       before :each do
-        stub_const('Utility::EsClient::MAX_RETRIES', 1)
+        stub_const('ES::Client::MAX_RETRIES', 1)
         allow(File).to receive(:open).and_yield(file_double)
         allow(Time).to receive(:now).and_return(fixed_time)
         stub_request(:post, "#{host}:#{port}/_bulk").to_return({ status: 404, exception: 'Consistent failure' })
@@ -160,7 +160,7 @@ RSpec.describe(Utility::EsClient) do
         )
 
         expect(File).to have_received(:open).with(
-          "#{Utility::EsClient::FAILED_BULKS_DIR}/crawl-id/#{fixed_time.strftime('%Y%m%d%H%M%S')}", 'w'
+          "#{ES::Client::FAILED_BULKS_DIR}/crawl-id/#{fixed_time.strftime('%Y%m%d%H%M%S')}", 'w'
         )
 
         expect(file_double).to have_received(:puts).with(payload[:body].first)


### PR DESCRIPTION
The `Utility` module contained only code relating to Elasticsearch, so I want to rename it.

- Refactor the `Utility` module into `ES` module
- Rename `EsClient` class to `Client`
