### PR TITLE
Bump rexml to 3.3.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,8 @@ GEM
     rainbow (3.1.1)
     rake (13.2.1)
     regexp_parser (2.9.0)
-    rexml (3.2.6)
+    rexml (3.3.4)
+      strscan
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -128,6 +129,7 @@ GEM
     slop (3.6.0)
     spoon (0.0.6)
       ffi
+    strscan (3.1.0-java)
     thread_safe (0.3.6-java)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)


### PR DESCRIPTION
Resolves the following dependabot alerts:

- https://github.com/elastic/crawler/security/dependabot/1
- https://github.com/elastic/crawler/security/dependabot/2
- https://github.com/elastic/crawler/security/dependabot/3