### PR TITLE
Update renovate to only consider chainguard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>elastic/renovate-config"
+    "github>elastic/renovate-config:only-chainguard"
   ]
 }


### PR DESCRIPTION
https://github.com/renovatebot/renovate/discussions/30782 seems to indicate that JRuby isn't really supported by renovate right now. Rather than manually fight each generated update, we'll just disable for now, but leave in place chainguard support for when we leverage wolfi images.


