### PR TITLE
Add extraction rules examples

### DIFF
--- a/config/crawler.yml.example
+++ b/config/crawler.yml.example
@@ -29,7 +29,7 @@
 #        pattern: /blog     # the pattern string for the rule
 #
 #    # An array of content extraction rules
-#    # See docs/features/CONTENT_EXTRACTION.md for more details on this feature
+#    # See docs/features/EXTRACTION_RULES.md for more details on this feature
 #    extraction_rulesets:
 #      - url_filters:
 #          - type: begins           # Filter type, can be: begins | ends | contains | regex

--- a/docs/DOCUMENT_SCHEMA.md
+++ b/docs/DOCUMENT_SCHEMA.md
@@ -6,7 +6,7 @@ These documents have a predefined list of fields that are always included.
 Crawler does not impose any mappings onto indices that it ingests docs into.
 This means you are free to create whatever mappings you like for an index, so long as you create the mappings _before_ indexing any documents.
 
-If any [content extraction](./features/CONTENT_EXTRACTION.md) rules have been configured, you can add more fields to the Elasticsearch documents.
+If any [content extraction rules](./features/EXTRACTION_RULES) have been configured, you can add more fields to the Elasticsearch documents.
 However, the predefined fields can never be changed or overwritten by content extraction rules.
 If you are ingesting onto an index that has custom mappings, be sure that the mappings don't conflict with these predefined fields.
 

--- a/docs/features/EXTRACTION_RULES.md
+++ b/docs/features/EXTRACTION_RULES.md
@@ -1,4 +1,9 @@
-# Content Extraction
+# Extraction Rules
+
+This document contains detailed explanation about the individual fields in the extraction ruleset configuration.
+There are also [example usages](#examples) at the end of this page.
+
+## Summary
 
 Extraction rules enable you to customize how the crawler extracts content from webpages.
 Extraction rules are configured in the Crawler config file.
@@ -113,3 +118,122 @@ Value can be anything except `null`.
 
 The source that Crawler will try to extract content from.
 Currently only `html` or `url` is supported.
+
+## Examples
+
+### Extracting from HTML
+
+I have a simple website for an RPG.
+A page describing cities in the RPG is hosted at `https://totally-real-rpg.com/cities`.
+The HTML for this page looks like this:
+
+```HTML
+<!DOCTYPE html>
+<html>
+  <body>
+    <div>Cities:</div>
+    <div class="city">Neverwinter</div>
+    <div class="city">Waterdeep</div>
+    <div class="city">Menzoberranzan</div>
+  </body>
+</html>
+```
+
+I want to extract all of the cities as an array, but only from the webpage that ends with `/cities`.
+First I must set the `url_filters` for this extraction rule to apply to only this URL.
+Then I can define what the Crawler should do when it encounters this webpage.
+
+```yaml
+domains:
+  - url: https://totally-real-rpg.com
+    extraction_rulesets:
+      - url_filters:
+          - type: "ends"
+            pattern: "/cities"
+        rules:
+          - action: "extract"
+            field_name: "cities"
+            selector: ".city"
+            join_as: "array"
+            source: "html"
+```
+
+In this example, the output document will include the following field on top of the standard crawl result fields:
+
+```json
+{
+  "cities": ["Neverwinter", "Waterdeep", "Menzoberranzan"]
+}
+```
+
+### Extracting from URLs
+
+Now, I also have a blog on this website.
+There are three posts on this blog, which fall under the following URLs:
+
+- https://totally-real-rpg.com/blog/2023/12/25/beginners-guide
+- https://totally-real-rpg.com/blog/2024/01/07/patch-1.0-changes
+- https://totally-real-rpg.com/blog/2024/02/18/upcoming-server-maintenance
+
+When these sites are crawled, I want to get only the year that the blog was published.
+First I should define the `url_filters` so that this extraction only applies to blogs.
+Then I can use a `regex` selector in the rule to fetch the year from the URL.
+
+```yaml
+domains:
+  - url: https://totally-real-rpg.com
+    extraction_rulesets:
+      - url_filters:
+          - type: "begins"
+            pattern: "/blog"
+        rules:
+          - action: "extract"
+            field_name: "publish_year"
+            selector: "posts\/([0-9]{4})"
+            join_as: "string"
+            source: "url"
+```
+In this example, the ingested documents will include the following fields on top of the standard crawl result fields:
+
+- https://totally-real-rpg.com/blog/2023/12/25/beginners-guide
+    ```json
+    { "publish_year": "2023" }
+    ```
+- https://totally-real-rpg.com/blog/2024/01/07/patch-1.0-changes
+    ```json
+    { "publish_year": "2024" }
+    ```
+- https://totally-real-rpg.com/blog/2024/02/18/upcoming-server-maintenance
+    ```json
+    { "publish_year": "2024" }
+    ```
+
+### Combined example
+
+Multiple extraction rulesets can be defined for a single Crawler.
+Taking the above two examples, we can combine them into a single configuration.
+There's no limit to the number of extraction rulesets that can be defined.
+
+```yaml
+domains:
+  - url: https://totally-real-rpg.com
+    extraction_rulesets:
+      - url_filters:
+            - type: "ends"
+              pattern: "/cities"
+        rules:
+          - action: "extract"
+            field_name: "cities"
+            selector: ".city"
+            join_as: "array"
+            source: "html"
+      - url_filters:
+          - type: "begins"
+            pattern: "/blog"
+        rules:
+          - action: "extract"
+            field_name: "publish_year"
+            selector: "posts\/([0-9]{4})"
+            join_as: "string"
+            source: "url"
+```

--- a/docs/features/EXTRACTION_RULES.md
+++ b/docs/features/EXTRACTION_RULES.md
@@ -208,11 +208,10 @@ In this example, the ingested documents will include the following fields on top
     { "publish_year": "2024" }
     ```
 
-### Combined example
+### Multiple rulesets
 
-Multiple extraction rulesets can be defined for a single Crawler.
+There's no limit to the number of extraction rulesets that can be defined for a single Crawler.
 Taking the above two examples, we can combine them into a single configuration.
-There's no limit to the number of extraction rulesets that can be defined.
 
 ```yaml
 domains:

--- a/docs/features/EXTRACTION_RULES.md
+++ b/docs/features/EXTRACTION_RULES.md
@@ -189,7 +189,7 @@ domains:
         rules:
           - action: "extract"
             field_name: "publish_year"
-            selector: "posts\/([0-9]{4})"
+            selector: "blog\/([0-9]{4})"
             join_as: "string"
             source: "url"
 ```
@@ -233,7 +233,7 @@ domains:
         rules:
           - action: "extract"
             field_name: "publish_year"
-            selector: "posts\/([0-9]{4})"
+            selector: "blog\/([0-9]{4})"
             join_as: "string"
             source: "url"
 ```

--- a/docs/features/EXTRACTION_RULES.md
+++ b/docs/features/EXTRACTION_RULES.md
@@ -1,7 +1,7 @@
 # Extraction Rules
 
-This document contains detailed explanation about the individual fields in the extraction ruleset configuration.
-There are also [example usages](#examples) at the end of this page.
+This page explains the individual fields in the extraction ruleset configuration.
+The last section provides [usage examples](#examples).
 
 ## Summary
 
@@ -132,9 +132,9 @@ The HTML for this page looks like this:
 <html>
   <body>
     <div>Cities:</div>
-    <div class="city">Neverwinter</div>
-    <div class="city">Waterdeep</div>
-    <div class="city">Menzoberranzan</div>
+    <div class="city">Summerstay</div>
+    <div class="city">Drenchwell</div>
+    <div class="city">Mezzoterran</div>
   </body>
 </html>
 ```
@@ -162,7 +162,7 @@ In this example, the output document will include the following field on top of 
 
 ```json
 {
-  "cities": ["Neverwinter", "Waterdeep", "Menzoberranzan"]
+  "cities": ["Summerstay", "Drenchwell", "Mezzoterran"]
 }
 ```
 


### PR DESCRIPTION
### Part of general docs improvements

- Rename `CONTENT_EXTRACTION.md` to `EXTRACTION_RULES.md` to better align with the actual feature name
- Add example configurations to `EXTRACTION_RULES.md`
