### PR TITLE
Add scheduling CLI command

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ group :default do
   gem 'elasticsearch', '~> 8.13.0'
   gem 'jar-dependencies', '0.4.1'
   gem 'json-schema', '~> 4.3.0'
+  gem 'rufus-scheduler', '~> 3.9.1'
   gem 'webrick', '~> 1.8.1'
 
   # Gems that need jruby as the platform

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,8 @@ GEM
       elasticsearch-api (= 8.13.0)
     elasticsearch-api (8.13.0)
       multi_json
+    et-orbi (1.2.11)
+      tzinfo
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     faraday (2.8.1)
@@ -46,6 +48,9 @@ GEM
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
     ffi (1.16.3-java)
+    fugit (1.11.1)
+      et-orbi (~> 1, >= 1.2.11)
+      raabro (~> 1.4)
     hashdiff (1.1.1)
     httpclient (2.8.3)
     i18n (1.14.4)
@@ -75,6 +80,7 @@ GEM
       pry (~> 0.9)
       slop (~> 3.0)
     public_suffix (6.0.1)
+    raabro (1.4.0)
     racc (1.7.3-java)
     rack (2.2.8.1)
     rack-mount (0.8.3)
@@ -118,6 +124,8 @@ GEM
       rake (>= 0.8.1)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    rufus-scheduler (3.9.1)
+      fugit (~> 1.1, >= 1.1.6)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -146,6 +154,7 @@ GEM
 PLATFORMS
   universal-java-17
   universal-java-21
+  universal-java-22
 
 DEPENDENCIES
   activesupport (= 6.1.7.7)
@@ -174,6 +183,7 @@ DEPENDENCIES
   rubocop-performance (= 1.11.5)
   ruby-debug-base (= 0.11.0)
   ruby-debug-ide
+  rufus-scheduler (~> 3.9.1)
   simplecov
   simplecov-material
   strscan (~> 3.1.0)

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -266,7 +266,7 @@ OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
-Library: bigdecimal 3.1.7
+Library: bigdecimal 3.1.8
 URL: https://github.com/ruby/bigdecimal
 License: Ruby OR BSD-2-Clause
 
@@ -1229,6 +1229,36 @@ License: Apache-2.0
    limitations under the License.
 
 --------------------------------------------------------------------------------
+Library: et-orbi 1.2.11
+URL: https://github.com/floraison/et-orbi
+License: MIT
+
+
+Copyright (c) 2017-2024, John Mettraux, jmettraux+flor@gmail.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+Made in Japan
+
+
+--------------------------------------------------------------------------------
 Library: faraday 2.8.1
 URL: https://lostisland.github.io/faraday
 License: MIT
@@ -1307,6 +1337,36 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+--------------------------------------------------------------------------------
+Library: fugit 1.11.1
+URL: https://github.com/floraison/fugit
+License: MIT
+
+
+Copyright (c) 2017-2024, John Mettraux, jmettraux+flor@gmail.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+Made in Japan
+
 
 --------------------------------------------------------------------------------
 Library: i18n 1.14.4
@@ -1574,6 +1634,36 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------------------
+Library: raabro 1.4.0
+URL: https://github.com/floraison/raabro
+License: MIT
+
+
+Copyright (c) 2015-2020, John Mettraux, jmettraux@gmail.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+Made in Japan.
+
+
+--------------------------------------------------------------------------------
 Library: racc 1.7.3
 URL: https://github.com/ruby/racc
 License: Ruby OR BSD-2-Clause
@@ -1680,6 +1770,33 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------------------
+Library: rufus-scheduler 3.9.1
+URL: https://github.com/jmettraux/rufus-scheduler
+License: MIT
+
+
+Copyright (c) 2005-2023, John Mettraux, jmettraux@gmail.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
 
 --------------------------------------------------------------------------------
 Library: strscan 3.1.0

--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ If using an API key, ensure that the API key has read and write permissions to a
 
 #### Running Open Crawler from Docker
 
+> [!IMPORTANT]
+> **Be wary of triggering multiple crawl jobs that reference the same index**.
+A single crawl execution can be thought of as a single crawler.
+Even if two crawl executions share a configuration file, the two crawl processes will not communicate with each other.
+Two crawlers simultaneously interacting with a single index can lead to data loss.
+
 Open Crawler has a Dockerfile that can be built and run locally.
 
 1. Clone the repository: `git clone https://github.com/elastic/crawler.git`
@@ -137,6 +143,32 @@ Open Crawler has a Dockerfile that can be built and run locally.
 ### Configuring Crawlers
 
 See [CONFIG.md](docs/CONFIG.md) for in-depth details on Open Crawler configuration files.
+
+### Scheduling Recurring Crawl Jobs
+
+Crawl jobs can also be scheduled to recur based on a cron expression.
+This expression needs to be included in the Crawler config file.
+You can use the tool https://crontab.guru to test different cron expressions.
+
+```yaml
+domains:
+  - url: "https://elastic.co"
+schedule:
+  - interval: "* * * * *" # run every minute
+```
+
+Then, use the CLI to then begin the crawl job schedule:
+
+```bash
+docker exec -it crawler bin/crawler schedule path/to/my-crawler.yml
+```
+
+**Scheduled crawl jobs from a single execution will not overlap.**
+If you have a schedule that triggers once per minute, but your crawl job takes 5 minutes to complete, the crawl schedule will effectively trigger about every 6 minutes.
+
+**Concurrently executed crawl schedules _will_ overlap**.
+Be wary of executing multiple schedules against the same index.
+As with ad-hoc triggered crawl jobs, two crawlers simultaneously interacting with a single index can lead to data loss.
 
 ### Crawler Document Schema and Mappings
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ If using an API key, ensure that the API key has read and write permissions to a
 #### Running Open Crawler from Docker
 
 > [!IMPORTANT]
-> **Be wary of triggering multiple crawl jobs that reference the same index**.
+> **Do not trigger multiple crawl jobs that reference the same index simultaneously.**
 A single crawl execution can be thought of as a single crawler.
 Even if two crawl executions share a configuration file, the two crawl processes will not communicate with each other.
 Two crawlers simultaneously interacting with a single index can lead to data loss.
@@ -160,7 +160,7 @@ See an example below for a crawl schedule that will execute once every 30 minute
 domains:
   - url: "https://elastic.co"
 schedule:
-  - interval: "*/30 * * * *" # run every 30th minute
+  - pattern: "*/30 * * * *" # run every 30th minute
 ```
 
 Then, use the CLI to then begin the crawl job schedule:
@@ -170,7 +170,9 @@ docker exec -it crawler bin/crawler schedule path/to/my-crawler.yml
 ```
 
 **Scheduled crawl jobs from a single execution will not overlap.**
-If you have a schedule that triggers once per minute, but your crawl job takes 5 minutes to complete, the crawl schedule will effectively trigger about every 6 minutes.
+Scheduled jobs will also not wait for existing jobs to complete.
+If a crawl job is already in progress when another schedule is triggered, the job will be dropped.
+For example, if you have a schedule that triggers at every hour, but your crawl job takes 1.5 hours to complete, the crawl schedule will effectively trigger on every 2nd hour.
 
 **Executing multiple crawl schedules _can_ cause overlap**.
 Be wary of executing multiple schedules against the same index.

--- a/README.md
+++ b/README.md
@@ -146,15 +146,21 @@ See [CONFIG.md](docs/CONFIG.md) for in-depth details on Open Crawler configurati
 
 ### Scheduling Recurring Crawl Jobs
 
-Crawl jobs can also be scheduled to recur based on a cron expression.
+Crawl jobs can also be scheduled to recur.
+Scheduled crawl jobs run until terminated by the user.
+
+These schedules are defined through a cron expression.
 This expression needs to be included in the Crawler config file.
 You can use the tool https://crontab.guru to test different cron expressions.
+Crawler supports all standard cron expressions.
+
+See an example below for a crawl schedule that will execute once every 30 minutes.
 
 ```yaml
 domains:
   - url: "https://elastic.co"
 schedule:
-  - interval: "* * * * *" # run every minute
+  - interval: "*/30 * * * *" # run every 30th minute
 ```
 
 Then, use the CLI to then begin the crawl job schedule:
@@ -166,7 +172,7 @@ docker exec -it crawler bin/crawler schedule path/to/my-crawler.yml
 **Scheduled crawl jobs from a single execution will not overlap.**
 If you have a schedule that triggers once per minute, but your crawl job takes 5 minutes to complete, the crawl schedule will effectively trigger about every 6 minutes.
 
-**Concurrently executed crawl schedules _will_ overlap**.
+**Executing multiple crawl schedules _can_ cause overlap**.
 Be wary of executing multiple schedules against the same index.
 As with ad-hoc triggered crawl jobs, two crawlers simultaneously interacting with a single index can lead to data loss.
 

--- a/config/crawler.yml.example
+++ b/config/crawler.yml.example
@@ -55,7 +55,7 @@
 #max_crawl_depth: 2
 #
 ## Scheduling using cron expressions
-#scheduling:
+#schedule:
 #  - interval: "0 12 * * *"     # every day at noon
 #
 ## Crawl result field size limits

--- a/config/crawler.yml.example
+++ b/config/crawler.yml.example
@@ -54,6 +54,10 @@
 ## The maximum depth that Crawler will follow links to.
 #max_crawl_depth: 2
 #
+## Scheduling using cron expressions
+#scheduling:
+#  - interval: "0 12 * * *"     # every day at noon
+#
 ## Crawl result field size limits
 #max_title_size: 1000
 #max_body_size: 5_242_880 # 5 megabytes

--- a/config/crawler.yml.example
+++ b/config/crawler.yml.example
@@ -56,7 +56,7 @@
 #
 ## Scheduling using cron expressions
 #schedule:
-#  - interval: "0 12 * * *"     # every day at noon
+#  - pattern: "0 12 * * *"     # every day at noon
 #
 ## Crawl result field size limits
 #max_title_size: 1000

--- a/lib/crawler/api/config.rb
+++ b/lib/crawler/api/config.rb
@@ -45,6 +45,7 @@ module Crawler
         :sitemap_urls,         # Array of sitemap URLs to be used for content discovery
         :crawl_rules,          # Array of allow/deny-listed URL patterns
         :extraction_rules,     # Contains domains extraction rules
+        :schedule,             # For scheduled jobs; not used outside of CLI
 
         :robots_txt_service,   # Service to fetch robots.txt
         :output_sink,          # The type of output, either :console | :file | :elasticsearch

--- a/lib/crawler/cli.rb
+++ b/lib/crawler/cli.rb
@@ -15,6 +15,7 @@ module Crawler
 
     register 'version', Crawler::CLI::Version, aliases: ['v', '--version']
     register 'crawl', Crawler::CLI::Crawl, aliases: %w[r run]
+    register 'schedule', Crawler::CLI::Schedule
     register 'validate', Crawler::CLI::Validate
   end
 end

--- a/lib/crawler/cli/schedule.rb
+++ b/lib/crawler/cli/schedule.rb
@@ -21,22 +21,22 @@ module Crawler
 
       def call(crawl_config:, es_config: nil, **)
         crawl_config = Crawler::CLI::Helpers.load_crawl_config(crawl_config, es_config)
-        if crawl_config.schedule.nil? || crawl_config.schedule[:interval].nil?
+        if crawl_config.schedule.nil? || crawl_config.schedule[:pattern].nil?
           raise ArgumentError, 'No schedule found in config file'
         end
 
-        run_schedule(crawl_config.schedule[:interval], crawl_config)
+        run_schedule(crawl_config.schedule[:pattern], crawl_config)
       end
 
-      def run_schedule(interval, crawl_config)
-        crawl_config.system_logger.info("Schedule initialized with an interval of #{interval}")
+      def run_schedule(pattern, crawl_config)
+        crawl_config.system_logger.info("Crawler initialized with a cron schedule of #{pattern}")
 
-        # Schedule a recurrent task based on the config value `schedule.interval`.
+        # Schedule a recurrent task based on the config value `schedule.pattern`.
         # The arg `overlap: false` prevents multiple tasks from spawning when a crawl
-        # task is longer than the schedule interval.
+        # task is longer than the schedule pattern.
         # This will run until the Crawler is terminated.
         scheduler = Rufus::Scheduler.new
-        scheduler.cron(interval, overlap: false) do |job|
+        scheduler.cron(pattern, overlap: false) do |job|
           crawl_config.system_logger.info(
             "Beginning scheduled crawl for #{job.previous_time} (actual trigger time: #{Time.now})."
           )

--- a/lib/crawler/cli/schedule.rb
+++ b/lib/crawler/cli/schedule.rb
@@ -1,0 +1,46 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+
+# frozen_string_literal: true
+
+require 'dry/cli'
+require 'yaml'
+require 'rufus-scheduler'
+
+module Crawler
+  module CLI
+    class Schedule < Dry::CLI::Command
+      desc 'Schedule a recurring crawl of the site'
+
+      argument :crawl_config, required: true, desc: 'Path to crawl config file'
+
+      option :es_config, desc: 'Path to elasticsearch config file'
+
+      def call(crawl_config:, es_config: nil, **)
+        crawl_config = Crawler::CLI::Helpers.load_crawl_config(crawl_config, es_config)
+        if crawl_config.schedule.nil? || crawl_config.schedule[:interval].nil?
+          raise ArgumentError, 'No schedule found in config file'
+        end
+
+        crawl_config.system_logger.info("Schedule initialized with an interval of #{crawl_config.schedule[:interval]}")
+
+        # Schedule a recurrent task based on the value in `schedule.interval`.
+        # Setting overlap=false prevents multiple tasks from spawning when a crawl
+        # task is longer than the schedule interval.
+        scheduler = Rufus::Scheduler.new
+
+        # TODO overlap not working, investigate
+        scheduler.cron(crawl_config.schedule[:interval], blocking=true, overlap=false) do
+          crawl_config.system_logger.info("Beginning a scheduled crawl...")
+          crawl = Crawler::API::Crawl.new(crawl_config)
+          crawl.start!
+          crawl_config.system_logger.info("Scheduled crawl complete.")
+        end
+        scheduler.join
+      end
+    end
+  end
+end

--- a/spec/fixtures/crawl.yml
+++ b/spec/fixtures/crawl.yml
@@ -6,7 +6,7 @@ domains:
       - https://localhost:80/news/
 
 schedule:
-  interval: '* * * * *'
+  pattern: '* * * * *'
 
 # Where to send the results. Possible values are console, file, or elasticsearch
 output_sink: elasticsearch

--- a/spec/fixtures/crawl.yml
+++ b/spec/fixtures/crawl.yml
@@ -5,6 +5,9 @@ domains:
       - https://localhost:80
       - https://localhost:80/news/
 
+schedule:
+  interval: '* * * * *'
+
 # Where to send the results. Possible values are console, file, or elasticsearch
 output_sink: elasticsearch
 
@@ -23,7 +26,8 @@ max_indexed_links_count: 5
 max_headings_count: 5
 
 elasticsearch:
-  host: http://localhost:9200
+  host: http://localhost
+  port: 9200
   username: elastic
   password: changeme
   bulk_api:

--- a/spec/lib/crawler/cli/schedule_spec.rb
+++ b/spec/lib/crawler/cli/schedule_spec.rb
@@ -42,31 +42,9 @@ RSpec.describe(Crawler::CLI::Schedule) do
       end
 
       it 'runs a crawl' do
-        expect(scheduler_mock).to receive(:cron).with('* * * * *', overlap=false).once
+        expect(scheduler_mock).to receive(:cron).with('* * * * *', overlap: false).once
 
         capture_output { cli.call(arguments: ['schedule', crawl_config]) }
-      end
-
-      context 'when crawl task takes longer than schedule interval' do
-        let(:crawl_config) { 'spec/fixtures/crawl.yml' }
-        let(:crawl_mock) { double }
-        let(:scheduler_mock) { double }
-
-        before(:example) do
-          allow(Crawler::API::Crawl).to receive(:new).and_return(crawl_mock)
-          allow(crawl_mock).to receive(:start!).and_return(true)
-
-          allow(Rufus::Scheduler).to receive(:new).and_return(scheduler_mock)
-          allow(scheduler_mock).to receive(:cron)
-          allow(scheduler_mock).to receive(:join)
-        end
-
-        it 'runs a crawl' do
-          expect(scheduler_mock).to receive(:cron).with('* * * * *', overlap=false).once
-          expect(crawl_mock).to receive(:start!).once
-
-          capture_output { cli.call(arguments: ['schedule', crawl_config]) }
-        end
       end
     end
 
@@ -74,13 +52,13 @@ RSpec.describe(Crawler::CLI::Schedule) do
       output = capture_output { cli.call(arguments: ['schedule', '-h']) }
       expected_output = <<~OUTPUT
         Command:
-          #{cmd} crawl
+          #{cmd} schedule
 
         Usage:
-          #{cmd} crawl CRAWL_CONFIG
+          #{cmd} schedule CRAWL_CONFIG
 
         Description:
-          Run a crawl of the site
+          Schedule a recurring crawl of the site
 
         Arguments:
           CRAWL_CONFIG                      # REQUIRED Path to crawl config file

--- a/spec/lib/crawler/cli/schedule_spec.rb
+++ b/spec/lib/crawler/cli/schedule_spec.rb
@@ -1,0 +1,96 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+
+# frozen_string_literal: true
+
+RSpec.describe(Crawler::CLI::Schedule) do
+  describe '.call' do
+    let(:cli) { Dry::CLI(Crawler::CLI) }
+
+    # Dry::CLI expects the command name to be the basename of the program
+    let(:cmd) { File.basename($PROGRAM_NAME, File.extname($PROGRAM_NAME)) }
+
+    context 'when crawl config is not provided' do
+      it 'shows an error message' do
+        output = capture_error { cli.call(arguments: ['schedule']) }
+        expect(output).to include("ERROR: \"#{cmd} schedule\" was called with no arguments")
+        expect(output).to include("Usage: \"#{cmd} schedule CRAWL_CONFIG\"")
+      end
+    end
+
+    context 'when a wrong crawl config is provided' do
+      let(:crawl_config) { 'spec/fixtures/non-existent-crawl.yml' }
+      it 'shows an error message' do
+        output = capture_output { cli.call(arguments: ['schedule', crawl_config]) }
+        expect(output).to include("ERROR: Config file #{crawl_config} does not exist!")
+      end
+    end
+
+    context 'when a crawl config is provided' do
+      let(:crawl_config) { 'spec/fixtures/crawl.yml' }
+      let(:crawl_mock) { double }
+      let(:scheduler_mock) { double }
+
+      before(:example) do
+        allow(Crawler::API::Crawl).to receive(:new).and_return(crawl_mock)
+        allow(Rufus::Scheduler).to receive(:new).and_return(scheduler_mock)
+        allow(scheduler_mock).to receive(:cron)
+        allow(scheduler_mock).to receive(:join)
+      end
+
+      it 'runs a crawl' do
+        expect(scheduler_mock).to receive(:cron).with('* * * * *', overlap=false).once
+
+        capture_output { cli.call(arguments: ['schedule', crawl_config]) }
+      end
+
+      context 'when crawl task takes longer than schedule interval' do
+        let(:crawl_config) { 'spec/fixtures/crawl.yml' }
+        let(:crawl_mock) { double }
+        let(:scheduler_mock) { double }
+
+        before(:example) do
+          allow(Crawler::API::Crawl).to receive(:new).and_return(crawl_mock)
+          allow(crawl_mock).to receive(:start!).and_return(true)
+
+          allow(Rufus::Scheduler).to receive(:new).and_return(scheduler_mock)
+          allow(scheduler_mock).to receive(:cron)
+          allow(scheduler_mock).to receive(:join)
+        end
+
+        it 'runs a crawl' do
+          expect(scheduler_mock).to receive(:cron).with('* * * * *', overlap=false).once
+          expect(crawl_mock).to receive(:start!).once
+
+          capture_output { cli.call(arguments: ['schedule', crawl_config]) }
+        end
+      end
+    end
+
+    it 'shows help page' do
+      output = capture_output { cli.call(arguments: ['schedule', '-h']) }
+      expected_output = <<~OUTPUT
+        Command:
+          #{cmd} crawl
+
+        Usage:
+          #{cmd} crawl CRAWL_CONFIG
+
+        Description:
+          Run a crawl of the site
+
+        Arguments:
+          CRAWL_CONFIG                      # REQUIRED Path to crawl config file
+
+        Options:
+          --es-config=VALUE                 # Path to elasticsearch config file
+          --help, -h                        # Print this help
+      OUTPUT
+
+      expect(output).to eq(expected_output)
+    end
+  end
+end


### PR DESCRIPTION
### Context

In the process of writing documentation for cron-based scheduling through bash scripts, I realised the UX was _terrible_. I looked around for an alternative and found [a library called `rufus-scheduler`](https://github.com/jmettraux/rufus-scheduler) that was really easy to tie into the existing CLI to allow for a `bin/crawler schedule` command.

### Changes

- Add the `bin/crawler schedule` CLI command
- Add `schedule.pattern` config value
  - This is a hash for future-proofing, in case we decide to support multiple schedule types instead of just cron expressions
- Use `rufus-scheduler` to create non-overlapping, recurrent crawl jobs
- Update documentation and example config file

### Note for reviewers

I couldn't figure out an effective way to test the `overlapping: false` argument for `rufus-scheduler`. I tested it locally and it works. My specific issue is that the scheduler will run until it's manually shutdown (e.g. sigint), so we need a way to exit the scheduler for tests to confirm the expected number of executions occurred.
Also, cron scheduling expressions support a minimum of 1 minute intervals, which makes for long unit tests to test this.

### Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] This PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `crawler.yml.example` and `elasticsearch.yml.example`)
- [x] This PR has a meaningful title
- [x] This PR links to all relevant GitHub issues that it fixes or partially addresses
    - If there is no GitHub issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v0.1.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference
- [x] Ran `make notice` if any dependencies have been added

### Release Note

Crawl jobs can now be scheduled using the CLI command `bin/crawler schedule`. See ./README.md#scheduling-recurring-crawl-jobs.