### PR TITLE
Fix crawl result logs

### DIFF
--- a/lib/crawler/api/crawl.rb
+++ b/lib/crawler/api/crawl.rb
@@ -141,7 +141,7 @@ module Crawler
         end
 
         outcome = combined_outcome(results)
-        message = "#{results[:primary][:message]} | #{results[:purge][:outcome]}"
+        message = "#{results[:primary][:message]} | #{results[:purge][:message]}"
         record_outcome(outcome:, message:)
       end
 

--- a/lib/crawler/coordinator.rb
+++ b/lib/crawler/coordinator.rb
@@ -99,6 +99,8 @@ module Crawler
 
       if purge_urls.empty?
         system_logger.info('No documents were found for the purge crawl. Skipping purge crawl.')
+        set_outcome(:success, "Successfully finished the #{@crawl_stage} crawl with an empty crawl queue")
+        log_crawl_end_event
         return
       end
 

--- a/lib/crawler/coordinator.rb
+++ b/lib/crawler/coordinator.rb
@@ -99,7 +99,7 @@ module Crawler
 
       if purge_urls.empty?
         system_logger.info('No documents were found for the purge crawl. Skipping purge crawl.')
-        set_outcome(:success, "Successfully finished the #{@crawl_stage} crawl with an empty crawl queue")
+        set_outcome(:success, "Skipped #{@crawl_stage} crawl as no outdated documents were found.")
         log_crawl_end_event
         return
       end


### PR DESCRIPTION
### Closes https://github.com/elastic/crawler/issues/128

Fix the crawl result log to correctly display `success` when no purge crawl was required.

- Update crawl stage status when skipping purge crawls
- Log correct outcome message in final log