### PR TITLE
Fix usage of in-built `File` lib

### DIFF
--- a/lib/crawler/output_sink/file.rb
+++ b/lib/crawler/output_sink/file.rb
@@ -25,7 +25,7 @@ module Crawler
       def write(crawl_result)
         doc = to_doc(crawl_result)
         result_file = "#{dir}/#{crawl_result.url_hash}.json"
-        File.write(result_file, doc.to_json)
+        ::File.write(result_file, doc.to_json)
 
         success
       end


### PR DESCRIPTION
### Closes https://github.com/elastic/crawler/issues/138

The output sink `Crawler::OutputSink::File` was calling the in-built lib `File`, but was confusing that lib for itself.
This forces the usage of `::File` so that ruby knows to use the internal lib instead.

(I'm not sure how this worked before, but possibly caused by upgrading the jruby version?)

### Release note

🐛  Fixed a bug that caused the `file` output sink to not work