### PR TITLE
Update ent-search-eng team to be a search-eng team

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -15,7 +15,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:ent-search-eng
+  owner: group:search-eng
   system: buildkite
   implementation:
     apiVersion: buildkite.elastic.dev/v1


### PR DESCRIPTION
### Description
As part of the global Search team's renaming, it's required to update the `ent-search-eng` team to the `search-eng`.

This PR is dedicated to renaming the `ent-search-eng` GitHub team to the `search-eng` team