### PR TITLE
Rename the ingestion-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo.
-*    @elastic/ingestion-team
+*    @elastic/search-extract-and-transform

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -30,7 +30,7 @@ spec:
       provider_settings:
         skip_pull_request_builds_for_existing_commits: false
       teams:
-        ingestion-team:
+        search-extract-and-transform:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
@@ -50,7 +50,7 @@ metadata:
       url: "https://buildkite.com/elastic/crawler-docker-build-publish"
 spec:
   type: "buildkite-pipeline"
-  owner: "group:ingestion-team"
+  owner: "group:search-extract-and-transform"
   system: "buildkite"
   implementation:
     apiVersion: "buildkite.elastic.dev/v1"
@@ -63,7 +63,7 @@ spec:
       provider_settings:
         trigger_mode: "none"
       teams:
-        ingestion-team: {}
+        search-extract-and-transform: {}
         search-productivity-team: {}
         everyone:
           access_level: "READ_ONLY"

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Enhancements that can be done after your initial contribution:
 ### Acceptance criteria
 
 All patch changes should have a corresponding GitHub issue filed within the repository.
-If you need changes that are complex, or you are not sure about how to do something, reach out to the [Ingestion team](https://github.com/orgs/elastic/teams/ingestion-team/members) and/or file an issue.
+If you need changes that are complex, or you are not sure about how to do something, reach out to the [Ingestion team](https://github.com/orgs/elastic/teams/search-extract-and-transform/members) and/or file an issue.
 
 ### Correct code/file organization
 


### PR DESCRIPTION
### Description
As part of the GitHub teams renaming initiative, it's required to rename the @elastic/ingestion-team to @elastic/search-extract-and-transform.

This PR is dedicated to renaming @elastic/ingestion-team to @elastic/search-extract-and-transform 