### PR TITLE
Pin rexml version to 3.3.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ group :default do
   gem 'elasticsearch', '~> 8.13.0'
   gem 'jar-dependencies', '0.4.1'
   gem 'json-schema', '~> 4.3.0'
+  gem 'rexml', '~> 3.3.8'
   gem 'rufus-scheduler', '~> 3.9.1'
   gem 'webrick', '~> 1.8.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,8 +88,7 @@ GEM
     rainbow (3.1.1)
     rake (13.2.1)
     regexp_parser (2.9.0)
-    rexml (3.3.5)
-      strscan
+    rexml (3.3.8)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -178,6 +177,7 @@ DEPENDENCIES
   pry-remote
   racc (~> 1.7.3)
   rack (~> 2.2.8.1)
+  rexml (~> 3.3.8)
   rspec (~> 3.13.0)
   rubocop (~> 1.63)
   rubocop-performance (= 1.11.5)


### PR DESCRIPTION
Pin `rexml` to 3.3.8 as 3.3.5 is insecure, see https://github.com/advisories/GHSA-vmwr-mc7x-5vc3