### PR TITLE
Upgrade rexml to 3.3.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ group :default do
   gem 'elasticsearch', '~> 8.13.0'
   gem 'jar-dependencies', '0.4.1'
   gem 'json-schema', '~> 4.3.0'
-  gem 'rexml', '~> 3.3.8'
+  gem 'rexml', '~> 3.3.9'
   gem 'rufus-scheduler', '~> 3.9.1'
   gem 'webrick', '~> 1.8.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
     rainbow (3.1.1)
     rake (13.2.1)
     regexp_parser (2.9.0)
-    rexml (3.3.8)
+    rexml (3.3.9)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -151,6 +151,7 @@ GEM
     zeitwerk (2.6.13)
 
 PLATFORMS
+  universal-java-11
   universal-java-17
   universal-java-21
   universal-java-22
@@ -177,7 +178,7 @@ DEPENDENCIES
   pry-remote
   racc (~> 1.7.3)
   rack (~> 2.2.8.1)
-  rexml (~> 3.3.8)
+  rexml (~> 3.3.9)
   rspec (~> 3.13.0)
   rubocop (~> 1.63)
   rubocop-performance (= 1.11.5)

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -528,28 +528,29 @@ Library: bundler 2.3.26
 URL: https://bundler.io
 License: MIT
 
-The MIT License
-
-Portions copyright (c) 2010-2019 André Arko
+Portions copyright (c) 2010 Andre Arko  
 Portions copyright (c) 2009 Engine Yard
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+MIT License
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------------------
 Library: concurrent-ruby 1.1.10
@@ -1742,6 +1743,34 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+--------------------------------------------------------------------------------
+Library: rexml 3.3.9
+URL: https://github.com/ruby/rexml
+License: BSD-2-Clause
+
+Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 Library: ruby2_keywords 0.0.5


### PR DESCRIPTION
### Closes elastic/search-team#8559

This is a transitive-only dependency which should not affect any production code:

```console
$ bundle info rexml
  * rexml (3.3.9)
        Summary: An XML toolkit for Ruby
        Homepage: https://github.com/ruby/rexml
        Changelog: https://github.com/ruby/rexml/releases/tag/v3.3.9
        Path: /Users/rachel/.rbenv/versions/jruby-9.4.7.0/lib/ruby/gems/shared/gems/rexml-3.3.9
        Reverse Dependencies:
                crack (1.0.0) depends on rexml (>= 0)
                rubocop (1.63.4) depends on rexml (>= 3.2.5, < 4.0)

$ bundle info crack
  * crack (1.0.0)
        Summary: Really simple JSON and XML parsing, ripped from Merb and Rails.
        Homepage: https://github.com/jnunemaker/crack
        Source Code: https://github.com/jnunemaker/crack
        Changelog: https://github.com/jnunemaker/crack/blob/master/History
        Bug Tracker: https://github.com/jnunemaker/crack/issues
        Path: /Users/rachel/.rbenv/versions/jruby-9.4.7.0/lib/ruby/gems/shared/gems/crack-1.0.0
        Reverse Dependencies:
                webmock (3.23.1) depends on crack (>= 0.3.2)
```

### Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [X] This PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `crawler.yml.example` and `elasticsearch.yml.example`)
- [X] This PR has a meaningful title
- [X] This PR links to all relevant GitHub issues that it fixes or partially addresses
    - If there is no GitHub issue, please create it. Each PR should have a link to an issue
- [X] this PR has a thorough description
- [X] Covered the changes with automated tests
- [X] Ran `make notice` if any dependencies have been added

### Related Pull Requests

<!-- TODO: Link elastic/ent-search PR once posted -->
