### PR TITLE
Increases test coverage for url validator code

### DIFF
--- a/spec/lib/crawler/url_validator/crawl_rules_check_spec.rb
+++ b/spec/lib/crawler/url_validator/crawl_rules_check_spec.rb
@@ -35,22 +35,20 @@ RSpec.describe(Crawler::UrlValidator) do
     context 'when the URL is allowed by a crawl rule' do
       let(:allowed) { true }
 
-      it 'calls validation_ok with the correct parameters' do
+      it 'calls validation_ok' do
         validator.validate_crawl_rules
         expect(validator)
           .to have_received(:validation_ok)
-          .with(:crawl_rules, 'The URL is allowed by one of the crawl rules', rule: 'some_rule_source')
       end
     end
 
     context 'when the URL is denied by a crawl rule' do
       let(:allowed) { false }
 
-      it 'calls validation_fail with the correct parameters' do
+      it 'calls validation_fail' do
         validator.validate_crawl_rules
         expect(validator)
           .to have_received(:validation_fail)
-          .with(:crawl_rules, 'The URL is denied by a crawl rule', rule: 'some_rule_source')
       end
     end
 
@@ -58,11 +56,10 @@ RSpec.describe(Crawler::UrlValidator) do
       let(:allowed) { false }
       let(:rule) { nil }
 
-      it 'calls validation_fail with the correct parameters' do
+      it 'calls validation_fail' do
         validator.validate_crawl_rules
         expect(validator)
           .to have_received(:validation_fail)
-          .with(:crawl_rules, 'The URL is denied because it did not match any rules')
       end
     end
   end

--- a/spec/lib/crawler/url_validator/crawl_rules_check_spec.rb
+++ b/spec/lib/crawler/url_validator/crawl_rules_check_spec.rb
@@ -9,7 +9,7 @@
 # Mock class definitions
 module Crawler
   module RuleEngine
-    class Elasticsearch
+    class Elasticsearch < Crawler::RuleEngine::Base
       def crawl_rules_outcome(url) end
     end
   end

--- a/spec/lib/crawler/url_validator/crawl_rules_check_spec.rb
+++ b/spec/lib/crawler/url_validator/crawl_rules_check_spec.rb
@@ -7,23 +7,24 @@
 # frozen_string_literal: true
 
 # Mock class definitions
-class Crawler::RuleEngine::Elasticsearch
-  def initialize(crawl_config) end
-
-  def crawl_rules_outcome(url) end
+module Crawler
+  module RuleEngine
+    class Elasticsearch
+      def crawl_rules_outcome(url) end
+    end
+  end
 end
 
 RSpec.describe(Crawler::UrlValidator) do
   let(:valid_url) { Crawler::Data::URL.parse('http://example.com') }
   let(:domain_allowlist) { ['example.com'] }
-  let(:crawl_config) { double('CrawlConfig', domain_allowlist: domain_allowlist) }
-  let(:validator) { described_class.new(url: valid_url, crawl_config: crawl_config) }
+  let(:crawl_config) { double('CrawlConfig', domain_allowlist:) }
+  let(:validator) { described_class.new(url: valid_url, crawl_config:) }
   let(:rule_engine) { double('Crawler::RuleEngine::Elasticsearch') }
-  let(:outcome) { double('Outcome', allowed?: allowed, details: { rule: rule }) }
+  let(:outcome) { double('Outcome', allowed?: allowed, details: { rule: }) }
   let(:rule) { double('Rule', source: 'some_rule_source') }
 
   describe '#validate_crawl_rules' do
-
     before do
       allow(Crawler::RuleEngine::Elasticsearch).to receive(:new).with(crawl_config).and_return(rule_engine)
       allow(rule_engine).to receive(:crawl_rules_outcome).with(validator.normalized_url).and_return(outcome)
@@ -38,7 +39,7 @@ RSpec.describe(Crawler::UrlValidator) do
         validator.validate_crawl_rules
         expect(validator)
           .to have_received(:validation_ok)
-                .with(:crawl_rules, 'The URL is allowed by one of the crawl rules', rule: 'some_rule_source')
+          .with(:crawl_rules, 'The URL is allowed by one of the crawl rules', rule: 'some_rule_source')
       end
     end
 
@@ -49,7 +50,7 @@ RSpec.describe(Crawler::UrlValidator) do
         validator.validate_crawl_rules
         expect(validator)
           .to have_received(:validation_fail)
-                .with(:crawl_rules, 'The URL is denied by a crawl rule', rule: 'some_rule_source')
+          .with(:crawl_rules, 'The URL is denied by a crawl rule', rule: 'some_rule_source')
       end
     end
 
@@ -61,9 +62,8 @@ RSpec.describe(Crawler::UrlValidator) do
         validator.validate_crawl_rules
         expect(validator)
           .to have_received(:validation_fail)
-                .with(:crawl_rules, 'The URL is denied because it did not match any rules')
+          .with(:crawl_rules, 'The URL is denied because it did not match any rules')
       end
     end
   end
-
 end

--- a/spec/lib/crawler/url_validator/crawl_rules_check_spec.rb
+++ b/spec/lib/crawler/url_validator/crawl_rules_check_spec.rb
@@ -1,0 +1,69 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+
+# frozen_string_literal: true
+
+# Mock class definitions
+class Crawler::RuleEngine::Elasticsearch
+  def initialize(crawl_config) end
+
+  def crawl_rules_outcome(url) end
+end
+
+RSpec.describe(Crawler::UrlValidator) do
+  let(:valid_url) { Crawler::Data::URL.parse('http://example.com') }
+  let(:domain_allowlist) { ['example.com'] }
+  let(:crawl_config) { double('CrawlConfig', domain_allowlist: domain_allowlist) }
+  let(:validator) { described_class.new(url: valid_url, crawl_config: crawl_config) }
+  let(:rule_engine) { double('Crawler::RuleEngine::Elasticsearch') }
+  let(:outcome) { double('Outcome', allowed?: allowed, details: { rule: rule }) }
+  let(:rule) { double('Rule', source: 'some_rule_source') }
+
+  describe '#validate_crawl_rules' do
+
+    before do
+      allow(Crawler::RuleEngine::Elasticsearch).to receive(:new).with(crawl_config).and_return(rule_engine)
+      allow(rule_engine).to receive(:crawl_rules_outcome).with(validator.normalized_url).and_return(outcome)
+      allow(validator).to receive(:validation_ok)
+      allow(validator).to receive(:validation_fail)
+    end
+
+    context 'when the URL is allowed by a crawl rule' do
+      let(:allowed) { true }
+
+      it 'calls validation_ok with the correct parameters' do
+        validator.validate_crawl_rules
+        expect(validator)
+          .to have_received(:validation_ok)
+                .with(:crawl_rules, 'The URL is allowed by one of the crawl rules', rule: 'some_rule_source')
+      end
+    end
+
+    context 'when the URL is denied by a crawl rule' do
+      let(:allowed) { false }
+
+      it 'calls validation_fail with the correct parameters' do
+        validator.validate_crawl_rules
+        expect(validator)
+          .to have_received(:validation_fail)
+                .with(:crawl_rules, 'The URL is denied by a crawl rule', rule: 'some_rule_source')
+      end
+    end
+
+    context 'when the URL is denied because it did not match any rules' do
+      let(:allowed) { false }
+      let(:rule) { nil }
+
+      it 'calls validation_fail with the correct parameters' do
+        validator.validate_crawl_rules
+        expect(validator)
+          .to have_received(:validation_fail)
+                .with(:crawl_rules, 'The URL is denied because it did not match any rules')
+      end
+    end
+  end
+
+end

--- a/spec/lib/crawler/url_validator/dns_check_spec.rb
+++ b/spec/lib/crawler/url_validator/dns_check_spec.rb
@@ -9,8 +9,8 @@
 RSpec.describe(Crawler::UrlValidator) do
   let(:valid_url) { Crawler::Data::URL.parse('http://example.com') }
   let(:domain_allowlist) { ['example.com'] }
-  let(:crawl_config) { double('CrawlConfig', domain_allowlist: domain_allowlist) }
-  let(:validator) { described_class.new(url: valid_url, crawl_config: crawl_config) }
+  let(:crawl_config) { double('CrawlConfig', domain_allowlist:) }
+  let(:validator) { described_class.new(url: valid_url, crawl_config:) }
 
   describe '#validate_dns' do
     before do
@@ -27,7 +27,7 @@ RSpec.describe(Crawler::UrlValidator) do
         validator.validate_dns
         expect(validator)
           .to have_received(:validation_warn)
-                .with(:dns, 'DNS resolution check could not be performed via an HTTP proxy.')
+          .with(:dns, 'DNS resolution check could not be performed via an HTTP proxy.')
       end
     end
 
@@ -48,7 +48,7 @@ RSpec.describe(Crawler::UrlValidator) do
           validator.validate_dns
           expect(validator)
             .to have_received(:validation_ok)
-                  .with(:dns, 'Domain name resolution successful: 1 addresses found', addresses: addresses)
+            .with(:dns, 'Domain name resolution successful: 1 addresses found', addresses:)
         end
       end
 
@@ -59,7 +59,7 @@ RSpec.describe(Crawler::UrlValidator) do
           validator.validate_dns
           expect(validator)
             .to have_received(:validation_fail)
-                  .with(:dns, 'DNS name resolution failed. No suitable addresses found!')
+            .with(:dns, 'DNS name resolution failed. No suitable addresses found!')
         end
       end
 
@@ -72,10 +72,9 @@ RSpec.describe(Crawler::UrlValidator) do
           validator.validate_dns
           expect(validator)
             .to have_received(:validation_fail)
-                  .with(:dns, /DNS resolution failure: DNS error. Please check the spelling of your domain/)
+            .with(:dns, /DNS resolution failure: DNS error. Please check the spelling of your domain/)
         end
       end
     end
   end
-
 end

--- a/spec/lib/crawler/url_validator/dns_check_spec.rb
+++ b/spec/lib/crawler/url_validator/dns_check_spec.rb
@@ -1,0 +1,81 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+
+# frozen_string_literal: true
+
+RSpec.describe(Crawler::UrlValidator) do
+  let(:valid_url) { Crawler::Data::URL.parse('http://example.com') }
+  let(:domain_allowlist) { ['example.com'] }
+  let(:crawl_config) { double('CrawlConfig', domain_allowlist: domain_allowlist) }
+  let(:validator) { described_class.new(url: valid_url, crawl_config: crawl_config) }
+
+  describe '#validate_dns' do
+    before do
+      validator.singleton_class.include(Crawler::UrlValidator::DnsCheckConcern)
+    end
+
+    context 'when proxy is configured' do
+      before do
+        allow(validator).to receive(:proxy_configured?).and_return(true)
+        allow(validator).to receive(:validation_warn)
+      end
+
+      it 'calls validation_warn with the correct parameters' do
+        validator.validate_dns
+        expect(validator)
+          .to have_received(:validation_warn)
+                .with(:dns, 'DNS resolution check could not be performed via an HTTP proxy.')
+      end
+    end
+
+    context 'when proxy is not configured' do
+      let(:resolv) { instance_double('Resolv') }
+      let(:addresses) { [Resolv::IPv4.create('127.0.0.1')] }
+
+      before do
+        allow(validator).to receive(:proxy_configured?).and_return(false)
+        allow(Resolv).to receive(:new).and_return(resolv)
+        allow(resolv).to receive(:getaddresses).and_return(addresses)
+        allow(validator).to receive(:validation_ok)
+        allow(validator).to receive(:validation_fail)
+      end
+
+      context 'when DNS resolution is successful' do
+        it 'calls validation_ok with the correct parameters' do
+          validator.validate_dns
+          expect(validator)
+            .to have_received(:validation_ok)
+                  .with(:dns, 'Domain name resolution successful: 1 addresses found', addresses: addresses)
+        end
+      end
+
+      context 'when DNS resolution fails with no addresses found' do
+        let(:addresses) { [] }
+
+        it 'calls validation_fail with the correct parameters' do
+          validator.validate_dns
+          expect(validator)
+            .to have_received(:validation_fail)
+                  .with(:dns, 'DNS name resolution failed. No suitable addresses found!')
+        end
+      end
+
+      context 'when DNS resolution raises an error' do
+        before do
+          allow(resolv).to receive(:getaddresses).and_raise(Resolv::ResolvError, 'DNS error')
+        end
+
+        it 'calls validation_fail with the correct parameters' do
+          validator.validate_dns
+          expect(validator)
+            .to have_received(:validation_fail)
+                  .with(:dns, /DNS resolution failure: DNS error. Please check the spelling of your domain/)
+        end
+      end
+    end
+  end
+
+end

--- a/spec/lib/crawler/url_validator/domain_access_check_spec.rb
+++ b/spec/lib/crawler/url_validator/domain_access_check_spec.rb
@@ -9,9 +9,9 @@
 RSpec.describe(Crawler::UrlValidator) do
   let(:valid_url) { Crawler::Data::URL.parse('http://example.com') }
   let(:domain_allowlist) { ['example.com'] }
-  let(:crawl_config) { double('CrawlConfig', domain_allowlist: domain_allowlist) }
+  let(:crawl_config) { double('CrawlConfig', domain_allowlist:) }
   let(:url) { instance_double('Crawler::Data::URL', domain: domain_allowlist[0], domain_name: domain_allowlist[0]) }
-  let(:validator) { described_class.new(url: valid_url, crawl_config: crawl_config) }
+  let(:validator) { described_class.new(url: valid_url, crawl_config:) }
 
   describe '#validate_domain_access' do
     before do
@@ -27,7 +27,7 @@ RSpec.describe(Crawler::UrlValidator) do
         validator.validate_domain_access
         expect(validator)
           .to have_received(:validation_ok)
-                .with(:domain_access, 'The URL matches one of the configured domains', domain: 'example.com')
+          .with(:domain_access, 'The URL matches one of the configured domains', domain: 'example.com')
       end
     end
 
@@ -38,9 +38,8 @@ RSpec.describe(Crawler::UrlValidator) do
         validator.validate_domain_access
         expect(validator)
           .to have_received(:validation_fail)
-                .with(:domain_access, 'The URL does not match any configured domains')
+          .with(:domain_access, 'The URL does not match any configured domains')
       end
     end
   end
-
 end

--- a/spec/lib/crawler/url_validator/domain_access_check_spec.rb
+++ b/spec/lib/crawler/url_validator/domain_access_check_spec.rb
@@ -1,0 +1,46 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+
+# frozen_string_literal: true
+
+RSpec.describe(Crawler::UrlValidator) do
+  let(:valid_url) { Crawler::Data::URL.parse('http://example.com') }
+  let(:domain_allowlist) { ['example.com'] }
+  let(:crawl_config) { double('CrawlConfig', domain_allowlist: domain_allowlist) }
+  let(:url) { instance_double('Crawler::Data::URL', domain: domain_allowlist[0], domain_name: domain_allowlist[0]) }
+  let(:validator) { described_class.new(url: valid_url, crawl_config: crawl_config) }
+
+  describe '#validate_domain_access' do
+    before do
+      validator.singleton_class.include(Crawler::UrlValidator::DomainAccessCheckConcern)
+      allow(validator).to receive(:crawler_api_config).and_return(crawl_config)
+      allow(validator).to receive(:url).and_return(url)
+      allow(validator).to receive(:validation_ok)
+      allow(validator).to receive(:validation_fail)
+    end
+
+    context 'when the URL matches one of the configured domains' do
+      it 'calls validation_ok with the correct parameters' do
+        validator.validate_domain_access
+        expect(validator)
+          .to have_received(:validation_ok)
+                .with(:domain_access, 'The URL matches one of the configured domains', domain: 'example.com')
+      end
+    end
+
+    context 'when the URL does not match any configured domains' do
+      let(:url) { instance_double('Crawler::Data::URL', domain: 'notexample.com', domain_name: 'notexample.com') }
+
+      it 'calls validation_fail with the correct parameters' do
+        validator.validate_domain_access
+        expect(validator)
+          .to have_received(:validation_fail)
+                .with(:domain_access, 'The URL does not match any configured domains')
+      end
+    end
+  end
+
+end

--- a/spec/lib/crawler/url_validator/domain_uniqueness_check_spec.rb
+++ b/spec/lib/crawler/url_validator/domain_uniqueness_check_spec.rb
@@ -9,8 +9,8 @@
 RSpec.describe(Crawler::UrlValidator) do
   let(:valid_url) { Crawler::Data::URL.parse('http://example.com') }
   let(:domain_allowlist) { ['example.com'] }
-  let(:crawl_config) { double('CrawlConfig', domain_allowlist: domain_allowlist) }
-  let(:validator) { described_class.new(url: valid_url, crawl_config: crawl_config) }
+  let(:crawl_config) { double('CrawlConfig', domain_allowlist:) }
+  let(:validator) { described_class.new(url: valid_url, crawl_config:) }
   let(:url) { instance_double('Crawler::Data::URL', domain: domain_allowlist[0], domain_name: domain_allowlist[0]) }
 
   describe '#validate_domain_uniqueness' do
@@ -27,7 +27,7 @@ RSpec.describe(Crawler::UrlValidator) do
         validator.validate_domain_uniqueness
         expect(validator)
           .to have_received(:validation_fail)
-                .with(:domain_uniqueness, 'Domain name already exists')
+          .with(:domain_uniqueness, 'Domain name already exists')
       end
     end
 
@@ -38,9 +38,8 @@ RSpec.describe(Crawler::UrlValidator) do
         validator.validate_domain_uniqueness
         expect(validator)
           .to have_received(:validation_ok)
-                .with(:domain_uniqueness, 'Domain name is new', domain: 'newexample.com')
+          .with(:domain_uniqueness, 'Domain name is new', domain: 'newexample.com')
       end
     end
   end
-
 end

--- a/spec/lib/crawler/url_validator/domain_uniqueness_check_spec.rb
+++ b/spec/lib/crawler/url_validator/domain_uniqueness_check_spec.rb
@@ -1,0 +1,46 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+
+# frozen_string_literal: true
+
+RSpec.describe(Crawler::UrlValidator) do
+  let(:valid_url) { Crawler::Data::URL.parse('http://example.com') }
+  let(:domain_allowlist) { ['example.com'] }
+  let(:crawl_config) { double('CrawlConfig', domain_allowlist: domain_allowlist) }
+  let(:validator) { described_class.new(url: valid_url, crawl_config: crawl_config) }
+  let(:url) { instance_double('Crawler::Data::URL', domain: domain_allowlist[0], domain_name: domain_allowlist[0]) }
+
+  describe '#validate_domain_uniqueness' do
+    before do
+      validator.singleton_class.include(Crawler::UrlValidator::DomainUniquenessCheckConcern)
+      allow(validator).to receive(:crawler_api_config).and_return(crawl_config)
+      allow(validator).to receive(:url).and_return(url)
+      allow(validator).to receive(:validation_ok)
+      allow(validator).to receive(:validation_fail)
+    end
+
+    context 'when the domain name already exists' do
+      it 'calls validation_fail with the correct parameters' do
+        validator.validate_domain_uniqueness
+        expect(validator)
+          .to have_received(:validation_fail)
+                .with(:domain_uniqueness, 'Domain name already exists')
+      end
+    end
+
+    context 'when the domain name is new' do
+      let(:url) { instance_double('Crawler::Data::URL', domain: 'newexample.com', domain_name: 'newexample.com') }
+
+      it 'calls validation_ok with the correct parameters' do
+        validator.validate_domain_uniqueness
+        expect(validator)
+          .to have_received(:validation_ok)
+                .with(:domain_uniqueness, 'Domain name is new', domain: 'newexample.com')
+      end
+    end
+  end
+
+end

--- a/spec/lib/crawler/url_validator/robots_txt_check_spec.rb
+++ b/spec/lib/crawler/url_validator/robots_txt_check_spec.rb
@@ -1,0 +1,128 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+
+# frozen_string_literal: true
+
+RSpec.describe(Crawler::UrlValidator) do
+  let(:valid_url) { Crawler::Data::URL.parse('http://example.com') }
+  let(:domain_allowlist) { ['example.com'] }
+  let(:crawl_config) { double('CrawlConfig', domain_allowlist: domain_allowlist) }
+  let(:validator) { described_class.new(url: valid_url, crawl_config: crawl_config) }
+  let(:crawl_task) { instance_double('Crawler::Data::CrawlTask') }
+  let(:http_executor) { double('HttpExecutor') }
+  let(:crawler_api_config) { double('CrawlerApiConfig', user_agent: 'TestAgent') }
+  let(:crawl_result) { Crawler::Data::CrawlResult::Error.new(url: Crawler::Data::URL.parse(valid_url), error:"error", status_code: 500) }
+
+  describe '#validate_robots_txt' do
+
+    before do
+      allow(validator).to receive(:http_executor).and_return(http_executor)
+      allow(validator).to receive(:crawler_api_config).and_return(crawler_api_config)
+      allow(Crawler::Data::CrawlTask).to receive(:new).and_return(crawl_task)
+      allow(http_executor).to receive(:run).with(crawl_task, follow_redirects: true).and_return(crawl_result)
+      allow(validator).to receive(:validation_warn)
+      allow(validator).to receive(:validation_ok)
+      allow(validator).to receive(:validation_fail)
+    end
+
+    context 'when there is a redirect error' do
+      before do
+        allow(crawl_result).to receive(:is_a?).with(Crawler::Data::CrawlResult::RedirectError).and_return(true)
+        allow(crawl_result).to receive(:error).and_return('Redirect error')
+      end
+
+      it 'returns a validation warning' do
+        expect(validator).to receive(:validation_warn).with(:robots_txt, /redirect error/)
+        validator.validate_robots_txt
+      end
+    end
+
+    context 'when robots.txt is not found (404)' do
+      before do
+        allow(crawl_result).to receive(:status_code).and_return(404)
+      end
+
+      it 'returns validation ok' do
+        expect(validator).to receive(:validation_ok).with(:robots_txt, /No robots.txt found/)
+        validator.validate_robots_txt
+      end
+    end
+
+    context 'when there is an internal error (599)' do
+      before do
+        allow(crawl_result).to receive(:status_code).and_return(599)
+        allow(crawl_result).to receive(:error).and_return('Internal error')
+        allow(crawl_result).to receive(:suggestion_message).and_return('Suggestion')
+      end
+
+      it 'returns a validation failure' do
+        expect(validator).to receive(:validation_fail).with(:robots_txt, /Failed to fetch robots.txt/)
+        validator.validate_robots_txt
+      end
+    end
+
+    context 'when there is a transient error (>= 500)' do
+      before do
+        allow(crawl_result).to receive(:status_code).and_return(500)
+      end
+
+      it 'returns a validation failure' do
+        expect(validator).to receive(:validation_fail).with(:robots_txt, /Transient error fetching robots.txt/)
+        validator.validate_robots_txt
+      end
+    end
+
+    context 'when robots.txt is fetched successfully' do
+      let(:robots_txt_service) { instance_double('Crawler::RobotsTxtService') }
+      let(:robots_txt_parser) { instance_double('RobotsTxtParser') }
+      let(:robots_outcome) { instance_double('RobotsOutcome') }
+
+      before do
+        allow(crawl_result).to receive(:status_code).and_return(200)
+        allow(Crawler::RobotsTxtService).to receive(:new).and_return(robots_txt_service)
+        allow(robots_txt_service).to receive(:register_crawl_result)
+        allow(robots_txt_service).to receive(:parser_for_domain).and_return(robots_txt_parser)
+        allow(robots_txt_parser).to receive(:allow_all?).and_return(false)
+        allow(robots_txt_service).to receive(:url_disallowed_outcome).and_return(robots_outcome)
+      end
+
+      context 'when robots.txt allows full access' do
+        before do
+          allow(robots_txt_parser).to receive(:allow_all?).and_return(true)
+        end
+
+        it 'returns validation ok' do
+          expect(validator).to receive(:validation_ok).with(:robots_txt, /allows us full access/)
+          validator.validate_robots_txt
+        end
+      end
+
+      context 'when robots.txt allows partial access' do
+        before do
+          allow(robots_outcome).to receive(:allowed?).and_return(true)
+        end
+
+        it 'returns a validation warning' do
+          expect(validator).to receive(:validation_warn).with(:robots_txt, /allows us access to the domain with some restrictions/)
+          validator.validate_robots_txt
+        end
+      end
+
+      context 'when robots.txt disallows access' do
+        before do
+          allow(robots_outcome).to receive(:allowed?).and_return(false)
+          allow(robots_outcome).to receive(:disallow_message).and_return('Disallow message')
+        end
+
+        it 'returns a validation failure' do
+          expect(validator).to receive(:validation_fail).with(:robots_txt, /disallows us access/)
+          validator.validate_robots_txt
+        end
+      end
+    end
+  end
+
+end

--- a/spec/lib/crawler/url_validator/robots_txt_check_spec.rb
+++ b/spec/lib/crawler/url_validator/robots_txt_check_spec.rb
@@ -9,15 +9,16 @@
 RSpec.describe(Crawler::UrlValidator) do
   let(:valid_url) { Crawler::Data::URL.parse('http://example.com') }
   let(:domain_allowlist) { ['example.com'] }
-  let(:crawl_config) { double('CrawlConfig', domain_allowlist: domain_allowlist) }
-  let(:validator) { described_class.new(url: valid_url, crawl_config: crawl_config) }
+  let(:crawl_config) { double('CrawlConfig', domain_allowlist:) }
+  let(:validator) { described_class.new(url: valid_url, crawl_config:) }
   let(:crawl_task) { instance_double('Crawler::Data::CrawlTask') }
   let(:http_executor) { double('HttpExecutor') }
   let(:crawler_api_config) { double('CrawlerApiConfig', user_agent: 'TestAgent') }
-  let(:crawl_result) { Crawler::Data::CrawlResult::Error.new(url: Crawler::Data::URL.parse(valid_url), error:"error", status_code: 500) }
+  let(:crawl_result) do
+    Crawler::Data::CrawlResult::Error.new(url: Crawler::Data::URL.parse(valid_url), error: 'error', status_code: 500)
+  end
 
   describe '#validate_robots_txt' do
-
     before do
       allow(validator).to receive(:http_executor).and_return(http_executor)
       allow(validator).to receive(:crawler_api_config).and_return(crawler_api_config)
@@ -106,7 +107,8 @@ RSpec.describe(Crawler::UrlValidator) do
         end
 
         it 'returns a validation warning' do
-          expect(validator).to receive(:validation_warn).with(:robots_txt, /allows us access to the domain with some restrictions/)
+          expect(validator).to receive(:validation_warn).with(:robots_txt,
+                                                              /allows us access to the domain with some restrictions/)
           validator.validate_robots_txt
         end
       end
@@ -124,5 +126,4 @@ RSpec.describe(Crawler::UrlValidator) do
       end
     end
   end
-
 end

--- a/spec/lib/crawler/url_validator/tcp_check_spec.rb
+++ b/spec/lib/crawler/url_validator/tcp_check_spec.rb
@@ -1,0 +1,105 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+
+# frozen_string_literal: true
+
+RSpec.describe(Crawler::UrlValidator) do
+  let(:valid_url) { Crawler::Data::URL.parse('http://example.com') }
+  let(:domain_allowlist) { ['example.com'] }
+  let(:crawl_config) { double('CrawlConfig', domain_allowlist: domain_allowlist) }
+  let(:validator) { described_class.new(url: valid_url, crawl_config: crawl_config) }
+  let(:host) { domain_allowlist[0] }
+  let(:port) { 80 }
+  let(:details) { { host: host, port: port } }
+  let(:url) { instance_double('Crawler::Data::URL', host: host, inferred_port: port) }
+
+  describe '#validate_tcp' do
+    before do
+      validator.singleton_class.include(Crawler::UrlValidator::TcpCheckConcern)
+      allow(validator).to receive(:proxy_configured?).and_return(proxy_configured)
+      allow(validator).to receive(:url).and_return(url)
+      allow(validator).to receive(:validation_ok)
+      allow(validator).to receive(:validation_warn)
+      allow(validator).to receive(:validation_fail)
+    end
+
+    context 'when proxy is configured' do
+      let(:proxy_configured) { true }
+
+      it 'calls validation_warn with the correct parameters' do
+        validator.validate_tcp
+        expect(validator)
+          .to have_received(:validation_warn)
+                .with(:tcp, 'TCP connection check could not be performed via an HTTP proxy.')
+      end
+    end
+
+    context 'when proxy is not configured' do
+      let(:proxy_configured) { false }
+
+      context 'when TCP connection is successful' do
+        before do
+          allow(Socket)
+            .to receive(:tcp)
+                  .with(host, port, connect_timeout: Crawler::UrlValidator::TCP_CHECK_TIMEOUT).and_yield
+        end
+
+        it 'calls validation_ok with the correct parameters' do
+          validator.validate_tcp
+          expect(validator)
+            .to have_received(:validation_ok)
+                  .with(:tcp, 'TCP connection successful', details)
+        end
+      end
+
+      context 'when TCP connection times out' do
+        before do
+          allow(Socket)
+            .to receive(:tcp)
+                  .with(host, port, connect_timeout: Crawler::UrlValidator::TCP_CHECK_TIMEOUT).and_raise(Errno::ETIMEDOUT)
+        end
+
+        it 'calls validation_fail with the correct parameters' do
+          validator.validate_tcp
+          expect(validator)
+            .to have_received(:validation_fail)
+                  .with(:tcp, /TCP connection to #{host}:#{port} timed out/, details)
+        end
+      end
+
+      context 'when TCP connection fails with a SocketError' do
+        before do
+          allow(Socket)
+            .to receive(:tcp)
+                  .with(host, port, connect_timeout: Crawler::UrlValidator::TCP_CHECK_TIMEOUT).and_raise(SocketError, 'socket error')
+        end
+
+        it 'calls validation_fail with the correct parameters' do
+          validator.validate_tcp
+          expect(validator)
+            .to have_received(:validation_fail)
+                  .with(:tcp, /TCP connection to #{host}:#{port} failed: socket error/, details)
+        end
+      end
+
+      context 'when TCP connection fails with a SystemCallError' do
+        before do
+          allow(Socket)
+            .to receive(:tcp)
+                  .with(host, port, connect_timeout: Crawler::UrlValidator::TCP_CHECK_TIMEOUT).and_raise(SystemCallError, 'system call error')
+        end
+
+        it 'calls validation_fail with the correct parameters' do
+          validator.validate_tcp
+          expect(validator)
+            .to have_received(:validation_fail)
+                  .with(:tcp, /TCP connection to #{host}:#{port} failed:/, details)
+        end
+      end
+    end
+  end
+
+end

--- a/spec/lib/crawler/url_validator/tcp_check_spec.rb
+++ b/spec/lib/crawler/url_validator/tcp_check_spec.rb
@@ -9,12 +9,12 @@
 RSpec.describe(Crawler::UrlValidator) do
   let(:valid_url) { Crawler::Data::URL.parse('http://example.com') }
   let(:domain_allowlist) { ['example.com'] }
-  let(:crawl_config) { double('CrawlConfig', domain_allowlist: domain_allowlist) }
-  let(:validator) { described_class.new(url: valid_url, crawl_config: crawl_config) }
+  let(:crawl_config) { double('CrawlConfig', domain_allowlist:) }
+  let(:validator) { described_class.new(url: valid_url, crawl_config:) }
   let(:host) { domain_allowlist[0] }
   let(:port) { 80 }
-  let(:details) { { host: host, port: port } }
-  let(:url) { instance_double('Crawler::Data::URL', host: host, inferred_port: port) }
+  let(:details) { { host:, port: } }
+  let(:url) { instance_double('Crawler::Data::URL', host:, inferred_port: port) }
 
   describe '#validate_tcp' do
     before do
@@ -33,7 +33,7 @@ RSpec.describe(Crawler::UrlValidator) do
         validator.validate_tcp
         expect(validator)
           .to have_received(:validation_warn)
-                .with(:tcp, 'TCP connection check could not be performed via an HTTP proxy.')
+          .with(:tcp, 'TCP connection check could not be performed via an HTTP proxy.')
       end
     end
 
@@ -44,14 +44,14 @@ RSpec.describe(Crawler::UrlValidator) do
         before do
           allow(Socket)
             .to receive(:tcp)
-                  .with(host, port, connect_timeout: Crawler::UrlValidator::TCP_CHECK_TIMEOUT).and_yield
+            .with(host, port, connect_timeout: Crawler::UrlValidator::TCP_CHECK_TIMEOUT).and_yield
         end
 
         it 'calls validation_ok with the correct parameters' do
           validator.validate_tcp
           expect(validator)
             .to have_received(:validation_ok)
-                  .with(:tcp, 'TCP connection successful', details)
+            .with(:tcp, 'TCP connection successful', details)
         end
       end
 
@@ -59,14 +59,14 @@ RSpec.describe(Crawler::UrlValidator) do
         before do
           allow(Socket)
             .to receive(:tcp)
-                  .with(host, port, connect_timeout: Crawler::UrlValidator::TCP_CHECK_TIMEOUT).and_raise(Errno::ETIMEDOUT)
+            .with(host, port, connect_timeout: Crawler::UrlValidator::TCP_CHECK_TIMEOUT).and_raise(Errno::ETIMEDOUT)
         end
 
         it 'calls validation_fail with the correct parameters' do
           validator.validate_tcp
           expect(validator)
             .to have_received(:validation_fail)
-                  .with(:tcp, /TCP connection to #{host}:#{port} timed out/, details)
+            .with(:tcp, /TCP connection to #{host}:#{port} timed out/, details)
         end
       end
 
@@ -74,14 +74,15 @@ RSpec.describe(Crawler::UrlValidator) do
         before do
           allow(Socket)
             .to receive(:tcp)
-                  .with(host, port, connect_timeout: Crawler::UrlValidator::TCP_CHECK_TIMEOUT).and_raise(SocketError, 'socket error')
+            .with(host, port, connect_timeout: Crawler::UrlValidator::TCP_CHECK_TIMEOUT)
+            .and_raise(SocketError, 'socket error')
         end
 
         it 'calls validation_fail with the correct parameters' do
           validator.validate_tcp
           expect(validator)
             .to have_received(:validation_fail)
-                  .with(:tcp, /TCP connection to #{host}:#{port} failed: socket error/, details)
+            .with(:tcp, /TCP connection to #{host}:#{port} failed: socket error/, details)
         end
       end
 
@@ -89,17 +90,17 @@ RSpec.describe(Crawler::UrlValidator) do
         before do
           allow(Socket)
             .to receive(:tcp)
-                  .with(host, port, connect_timeout: Crawler::UrlValidator::TCP_CHECK_TIMEOUT).and_raise(SystemCallError, 'system call error')
+            .with(host, port, connect_timeout: Crawler::UrlValidator::TCP_CHECK_TIMEOUT)
+            .and_raise(SystemCallError, 'system call error')
         end
 
         it 'calls validation_fail with the correct parameters' do
           validator.validate_tcp
           expect(validator)
             .to have_received(:validation_fail)
-                  .with(:tcp, /TCP connection to #{host}:#{port} failed:/, details)
+            .with(:tcp, /TCP connection to #{host}:#{port} failed:/, details)
         end
       end
     end
   end
-
 end

--- a/spec/lib/crawler/url_validator/url_check_spec.rb
+++ b/spec/lib/crawler/url_validator/url_check_spec.rb
@@ -9,13 +9,13 @@
 RSpec.describe(Crawler::UrlValidator) do
   let(:valid_url) { Crawler::Data::URL.parse('http://example.com') }
   let(:domain_allowlist) { ['example.com'] }
-  let(:crawl_config) { double('CrawlConfig', domain_allowlist: domain_allowlist) }
-  let(:validator) { described_class.new(url: valid_url, crawl_config: crawl_config) }
+  let(:crawl_config) { double('CrawlConfig', domain_allowlist:) }
+  let(:validator) { described_class.new(url: valid_url, crawl_config:) }
   let(:scheme) { 'http' }
   let(:supported_scheme) { true }
   let(:path) { '' }
   let(:configuration) { true }
-  let(:url) { instance_double('Crawler::Data::URL', scheme: scheme, supported_scheme?: supported_scheme, path: path) }
+  let(:url) { instance_double('Crawler::Data::URL', scheme:, supported_scheme?: supported_scheme, path:) }
 
   describe '#validate_url' do
     before do
@@ -23,8 +23,7 @@ RSpec.describe(Crawler::UrlValidator) do
       Crawler::UrlValidator.class_eval do
         private
 
-        def configuration
-        end
+        def configuration; end
       end
 
       validator.singleton_class.include(Crawler::UrlValidator::UrlCheckConcern)
@@ -46,7 +45,7 @@ RSpec.describe(Crawler::UrlValidator) do
         validator.validate_url
         expect(validator)
           .to have_received(:validation_fail)
-                .with(:url, 'URL scheme is missing. Domain URLs must start with https:// or http://')
+          .with(:url, 'URL scheme is missing. Domain URLs must start with https:// or http://')
       end
     end
 
@@ -57,7 +56,7 @@ RSpec.describe(Crawler::UrlValidator) do
         validator.validate_url
         expect(validator)
           .to have_received(:validation_fail)
-                .with(:url, "Unsupported URL scheme: #{scheme}", scheme: scheme)
+          .with(:url, "Unsupported URL scheme: #{scheme}", scheme:)
       end
     end
 
@@ -69,7 +68,7 @@ RSpec.describe(Crawler::UrlValidator) do
         validator.validate_url
         expect(validator)
           .to have_received(:validation_fail)
-                .with(:url, 'Domain URLs cannot contain a path')
+          .with(:url, 'Domain URLs cannot contain a path')
       end
     end
 
@@ -78,7 +77,7 @@ RSpec.describe(Crawler::UrlValidator) do
         validator.validate_url
         expect(validator)
           .to have_received(:validation_ok)
-                .with(:url, 'URL structure looks valid')
+          .with(:url, 'URL structure looks valid')
       end
     end
 
@@ -91,9 +90,8 @@ RSpec.describe(Crawler::UrlValidator) do
         validator.validate_url
         expect(validator)
           .to have_received(:validation_fail)
-                .with(:url, 'Error parsing domain name: invalid URI')
+          .with(:url, 'Error parsing domain name: invalid URI')
       end
     end
   end
-
 end

--- a/spec/lib/crawler/url_validator/url_check_spec.rb
+++ b/spec/lib/crawler/url_validator/url_check_spec.rb
@@ -1,0 +1,99 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+
+# frozen_string_literal: true
+
+RSpec.describe(Crawler::UrlValidator) do
+  let(:valid_url) { Crawler::Data::URL.parse('http://example.com') }
+  let(:domain_allowlist) { ['example.com'] }
+  let(:crawl_config) { double('CrawlConfig', domain_allowlist: domain_allowlist) }
+  let(:validator) { described_class.new(url: valid_url, crawl_config: crawl_config) }
+  let(:scheme) { 'http' }
+  let(:supported_scheme) { true }
+  let(:path) { '' }
+  let(:configuration) { true }
+  let(:url) { instance_double('Crawler::Data::URL', scheme: scheme, supported_scheme?: supported_scheme, path: path) }
+
+  describe '#validate_url' do
+    before do
+      # Define a temporary method for testing
+      Crawler::UrlValidator.class_eval do
+        private
+
+        def configuration
+        end
+      end
+
+      validator.singleton_class.include(Crawler::UrlValidator::UrlCheckConcern)
+      allow(validator).to receive(:url).and_return(url)
+      allow(validator).to receive(:configuration)
+      allow(validator).to receive(:validation_ok)
+      allow(validator).to receive(:validation_fail)
+    end
+
+    after do
+      # Remove the temporary method after testing
+      Crawler::UrlValidator.send(:remove_method, :configuration)
+    end
+
+    context 'when URL scheme is missing' do
+      let(:scheme) { '' }
+
+      it 'calls validation_fail with the correct parameters' do
+        validator.validate_url
+        expect(validator)
+          .to have_received(:validation_fail)
+                .with(:url, 'URL scheme is missing. Domain URLs must start with https:// or http://')
+      end
+    end
+
+    context 'when URL scheme is unsupported' do
+      let(:supported_scheme) { false }
+
+      it 'calls validation_fail with the correct parameters' do
+        validator.validate_url
+        expect(validator)
+          .to have_received(:validation_fail)
+                .with(:url, "Unsupported URL scheme: #{scheme}", scheme: scheme)
+      end
+    end
+
+    context 'when URL contains a path and configuration is not present' do
+      let(:path) { '/somepath' }
+      let(:configuration) { false }
+
+      it 'calls validation_fail with the correct parameters' do
+        validator.validate_url
+        expect(validator)
+          .to have_received(:validation_fail)
+                .with(:url, 'Domain URLs cannot contain a path')
+      end
+    end
+
+    context 'when URL structure is valid' do
+      it 'calls validation_ok with the correct parameters' do
+        validator.validate_url
+        expect(validator)
+          .to have_received(:validation_ok)
+                .with(:url, 'URL structure looks valid')
+      end
+    end
+
+    context 'when there is an error parsing the domain name' do
+      before do
+        allow(url).to receive(:scheme).and_raise(Addressable::URI::InvalidURIError, 'invalid URI')
+      end
+
+      it 'calls validation_fail with the correct parameters' do
+        validator.validate_url
+        expect(validator)
+          .to have_received(:validation_fail)
+                .with(:url, 'Error parsing domain name: invalid URI')
+      end
+    end
+  end
+
+end

--- a/spec/lib/crawler/url_validator/url_content_check_spec.rb
+++ b/spec/lib/crawler/url_validator/url_content_check_spec.rb
@@ -1,0 +1,158 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+
+# frozen_string_literal: true
+
+RSpec.describe(Crawler::UrlValidator) do
+  let(:valid_url) { Crawler::Data::URL.parse('http://example.com') }
+  let(:domain_allowlist) { ['example.com'] }
+  let(:crawl_config) { double('CrawlConfig', domain_allowlist: domain_allowlist) }
+  let(:validator) { described_class.new(url: valid_url, crawl_config: crawl_config) }
+  let(:url) { Crawler::Data::URL.parse(valid_url) }
+  let(:content) do
+    <<~HTML
+      <html>
+        <head>
+          <title>Title</title>
+          <meta name="keywords" content="Keywords">
+          <meta name="description" content="Description">
+        </head>
+        <body>
+          Some content
+          <a href="http://example.com/link1">Link1</a>
+          <a href="http://example.com/link2">Link2</a>
+        </body>
+      </html>
+    HTML
+  end
+  let(:url_crawl_result_html) { Crawler::Data::CrawlResult::HTML.new(status_code: 200, content: content, url: url) }
+  let(:url_crawl_result_error) { Crawler::Data::CrawlResult::Error.new(url:url, suggestion_message: 'suggestion message', error: 'error') }
+  let(:url_crawl_result_redirect) { instance_double('Crawler::Data::CrawlResult::Redirect', redirect?: true, location: 'http://redirected.com') }
+  let(:url_crawl_result_redirect_error) { instance_double('Crawler::Data::CrawlResult::RedirectError', redirect?: false, suggestion_message: 'suggestion message', content_type: 'unknown') }
+  let(:crawler_api_config) { instance_double('CrawlConfig', max_title_size: 100, max_keywords_size: 100, max_description_size: 100) }
+
+  describe '#validate_url_content' do
+    before do
+      validator.singleton_class.include(Crawler::UrlValidator::UrlContentCheckConcern)
+      allow(validator).to receive(:crawler_api_config).and_return(crawler_api_config)
+      allow(validator).to receive(:validate_url_request)
+      allow(validator).to receive(:validation_ok)
+      allow(validator).to receive(:validation_warn)
+      allow(validator).to receive(:validation_fail)
+    end
+
+    context 'when URL content is HTML but body is empty' do
+      let(:content) { '<html><head><title>Title</title></head><body></body></html>' }
+
+      before do
+        allow(validator).to receive(:url_crawl_result).and_return(url_crawl_result_html)
+      end
+
+      it 'calls validation_warn with the correct parameters' do
+        validator.validate_url_content
+        expect(validator)
+          .to have_received(:validation_warn)
+                .with(:url_content, "The web page at #{validator.url} did not return enough content to index.")
+      end
+    end
+
+    context 'when URL content is HTML and body is not empty' do
+      before do
+        allow(validator).to receive(:url_crawl_result).and_return(url_crawl_result_html)
+      end
+
+      it 'calls validation_ok with follow' do
+        validator.validate_url_content
+        expect(validator).to have_received(:validation_ok).twice
+      end
+
+    end
+
+    context 'when there are links in the content' do
+
+      before do
+        allow(validator).to receive(:url_crawl_result).and_return(url_crawl_result_html)
+      end
+
+      it 'calls validation_ok with the correct parameters for links' do
+        validator.validate_url_content
+        expect(validator).to have_received(:validation_ok).with(
+          :url_content,
+          "Successfully extracted some links from #{validator.url}.",
+          links_sample: ['http://example.com/link1', 'http://example.com/link2']
+        )
+      end
+    end
+
+    context 'when there are no links in the content' do
+      let(:content) { '<html><head><title>Title</title></head><body>Some content</body></html>' }
+
+      before do
+        allow(validator).to receive(:url_crawl_result).and_return(url_crawl_result_html)
+      end
+
+      it 'calls validation_warn with the correct parameters for no links' do
+        validator.validate_url_content
+        expect(validator).to have_received(:validation_warn).with(
+          :url_content,
+          /The web page at #{validator.url} has no links in it at all/
+        )
+      end
+    end
+
+    context 'when URL is redirected' do
+      before do
+        allow(validator).to receive(:url_crawl_result).and_return(url_crawl_result_redirect)
+      end
+
+      it 'calls validation_warn_from_crawl_redirect' do
+        expect(validator).to receive(:validation_warn_from_crawl_redirect)
+        validator.validate_url_content
+      end
+
+      it 'calls validation_warn with the correct parameters' do
+        validator.validate_url_content
+        expect(validator).to have_received(:validation_warn).with(
+          :url_content,
+          "The web page at #{validator.url} redirected us to http://redirected.com,\nplease make sure the destination page contains some indexable\ncontent and is allowed by crawl rules before starting your crawl.\n",
+          location: 'http://redirected.com'
+        )
+      end
+
+      context 'when validation_fail_from_crawl_error with redirect error' do
+        before do
+          allow(validator).to receive(:url_crawl_result).and_return(url_crawl_result_redirect_error)
+        end
+
+        it 'calls validation_fail_from_crawl_error with redirect error result' do
+          validator.validate_url_content
+          expect(validator).to have_received(:validation_fail).with(
+            :url_content,
+            "When we fetched the web page at #{validator.url}, the server returned data that was not HTML.\nsuggestion message\n",
+            content_type: 'unknown'
+          )
+        end
+      end
+    end
+
+    context 'when validation_fail_from_crawl_error' do
+      before do
+        allow(validator).to receive(:url_crawl_result).and_return(url_crawl_result_error)
+      end
+
+      it 'calls validation_fail_from_crawl_error with crawl error' do
+        validator.validate_url_content
+        expect(validator).to have_received(:validation_fail).with(
+          :url_content,
+          "When we fetched the web page at #{validator.url}, an unexpected error occurred: error.\nsuggestion message\n",
+          content_type: 'unknown'
+        )
+      end
+    end
+
+  end
+
+end

--- a/spec/lib/crawler/url_validator/url_request_check_spec.rb
+++ b/spec/lib/crawler/url_validator/url_request_check_spec.rb
@@ -1,0 +1,149 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+
+# frozen_string_literal: true
+
+RSpec.describe(Crawler::UrlValidator) do
+  let(:valid_url) { Crawler::Data::URL.parse('http://example.com') }
+  let(:domain_allowlist) { ['example.com'] }
+  let(:crawl_config) { double('CrawlConfig', domain_allowlist: domain_allowlist) }
+  let(:http_executor) { double('HttpExecutor') }
+  let(:url_crawl_result) { double('UrlCrawlResult', status_code: 200, content_type: 'text/html', duration: 0.5, location: nil, error: nil, suggestion_message: nil) }
+  let(:url_crawl_result_redirect) { instance_double('Crawler::Data::CrawlResult::Redirect', redirect?: true, location: Crawler::Data::URL.parse('http://redirected.com')) }
+  let(:validator) { described_class.new(url: valid_url, crawl_config: crawl_config) }
+
+
+
+  describe '#validate_url_request' do
+    before do
+      allow(validator).to receive(:http_executor).and_return(http_executor)
+      allow(http_executor).to receive(:run).and_return(url_crawl_result)
+    end
+
+    context 'when the status code is 200' do
+      it 'validates successfully' do
+        expect(validator).to receive(:validation_ok).with(:url_request, "Successfully fetched #{valid_url}: HTTP 200.", hash_including(:status_code, :content_type, :request_time_msec))
+        validator.validate_url_request
+      end
+    end
+
+    context 'when the status code is 204' do
+      before { allow(url_crawl_result).to receive(:status_code).and_return(204) }
+
+      it 'fails validation with no content message' do
+        expect(validator).to receive(:validation_fail).with(:url_request, "The Web server at #{valid_url} returned no content (HTTP 204).", hash_including(:status_code, :content_type, :request_time_msec))
+        validator.validate_url_request
+      end
+    end
+
+    context 'when the status code is a redirect (301, 302, 303, 307, 308)' do
+      before { allow(url_crawl_result).to receive(:status_code).and_return(301) }
+
+      it 'calls redirect_validation_result' do
+        expect(validator).to receive(:redirect_validation_result).with(hash_including(:status_code, :content_type, :request_time_msec))
+        validator.validate_url_request
+      end
+    end
+
+    context 'when the status code is 401' do
+      before { allow(url_crawl_result).to receive(:status_code).and_return(401) }
+
+      it 'calls unauthorized_validation_result' do
+        expect(validator).to receive(:unauthorized_validation_result).with(hash_including(:status_code, :content_type, :request_time_msec))
+        validator.validate_url_request
+      end
+    end
+
+    context 'when the status code is 403' do
+      before { allow(url_crawl_result).to receive(:status_code).and_return(403) }
+
+      it 'fails validation with forbidden message' do
+        expect(validator)
+          .to receive(:validation_fail)
+                .with(:url_request, "The web server at #{valid_url} denied us permission to view that page (HTTP 403).\nThis website may require a user name and password.\nRead more at: https://www.elastic.co/guide/en/enterprise-search/current/crawler-managing.html#crawler-managing-authentication.\n", hash_including(:status_code, :content_type, :request_time_msec))
+        validator.validate_url_request
+      end
+    end
+
+    context 'when the status code is 404' do
+      before { allow(url_crawl_result).to receive(:status_code).and_return(404) }
+
+      it 'fails validation with not found message' do
+        expect(validator)
+          .to receive(:validation_fail)
+                .with(:url_request, "The web server at #{valid_url} says that there is no web page at that location (HTTP 404).\n", hash_including(:status_code, :content_type, :request_time_msec))
+        validator.validate_url_request
+      end
+    end
+
+    context 'when the status code is 407' do
+      before { allow(url_crawl_result).to receive(:status_code).and_return(407) }
+
+      it 'fails validation with proxy authentication required message' do
+        expect(validator).to receive(:validation_fail).with(:url_request, "The web server at #{valid_url} is configured to require an HTTP proxy for access (HTTP 407).\nThis may mean that you're trying to index an internal (intranet) server.\nRead more at: https://www.elastic.co/guide/en/enterprise-search/current/crawler-private-network-cloud.html.\n", hash_including(:status_code, :content_type, :request_time_msec))
+        validator.validate_url_request
+      end
+    end
+
+    context 'when the status code is 429' do
+      before { allow(url_crawl_result).to receive(:status_code).and_return(429) }
+
+      it 'fails validation with rate limiting message' do
+        expect(validator).to receive(:validation_fail).with(:url_request, "The web server at #{valid_url} refused our connection due to request\nrate-limiting (HTTP 429).\n", hash_including(:status_code, :content_type, :request_time_msec))
+        validator.validate_url_request
+      end
+    end
+
+    context 'when the status code is 451' do
+      before { allow(url_crawl_result).to receive(:status_code).and_return(451) }
+
+      it 'fails validation with legal reasons message' do
+        expect(validator).to receive(:validation_fail).with(:url_request, "The web server at #{valid_url} refused our connection due to legal reasons (HTTP 451).\n", hash_including(:status_code, :content_type, :request_time_msec))
+        validator.validate_url_request
+      end
+    end
+
+    context 'when the status code is between 400 and 499' do
+      before { allow(url_crawl_result).to receive(:status_code).and_return(418) }
+
+      it 'fails validation with client error message' do
+        expect(validator).to receive(:validation_fail).with(:url_request, "Failed to fetch #{valid_url}: HTTP 418.", hash_including(:status_code, :content_type, :request_time_msec))
+        validator.validate_url_request
+      end
+    end
+
+    context 'when the status code is between 500 and 598' do
+      before { allow(url_crawl_result).to receive(:status_code).and_return(500) }
+
+      it 'fails validation with server error message' do
+        expect(validator).to receive(:validation_fail).with(:url_request, "Transient error fetching #{valid_url}: HTTP 500.", hash_including(:status_code, :content_type, :request_time_msec))
+        validator.validate_url_request
+      end
+    end
+
+    context 'when the status code is 599' do
+      before { allow(url_crawl_result).to receive(:status_code).and_return(599) }
+      before { allow(url_crawl_result).to receive(:error).and_return('Some error') }
+      before { allow(url_crawl_result).to receive(:suggestion_message).and_return('Some suggestion') }
+
+      it 'fails validation with unexpected error message' do
+        expect(validator).to receive(:validation_fail).with(:url_request, "Unexpected error fetching #{valid_url}: Some error.\nSome suggestion\n", hash_including(:status_code, :content_type, :request_time_msec))
+        validator.validate_url_request
+      end
+    end
+
+    context 'when the status code is unexpected' do
+      before { allow(url_crawl_result).to receive(:status_code).and_return(999) }
+
+      it 'fails validation with unexpected status message' do
+        expect(validator).to receive(:validation_fail).with(:url_request, "Unexpected HTTP status while fetching #{valid_url}: HTTP 999.\n", hash_including(:status_code, :content_type, :request_time_msec))
+        validator.validate_url_request
+      end
+    end
+  end
+
+
+end

--- a/spec/lib/crawler/url_validator/url_request_check_spec.rb
+++ b/spec/lib/crawler/url_validator/url_request_check_spec.rb
@@ -9,13 +9,18 @@
 RSpec.describe(Crawler::UrlValidator) do
   let(:valid_url) { Crawler::Data::URL.parse('http://example.com') }
   let(:domain_allowlist) { ['example.com'] }
-  let(:crawl_config) { double('CrawlConfig', domain_allowlist: domain_allowlist) }
+  let(:crawl_config) { double('CrawlConfig', domain_allowlist:) }
   let(:http_executor) { double('HttpExecutor') }
-  let(:url_crawl_result) { double('UrlCrawlResult', status_code: 200, content_type: 'text/html', duration: 0.5, location: nil, error: nil, suggestion_message: nil) }
-  let(:url_crawl_result_redirect) { instance_double('Crawler::Data::CrawlResult::Redirect', redirect?: true, location: Crawler::Data::URL.parse('http://redirected.com')) }
-  let(:validator) { described_class.new(url: valid_url, crawl_config: crawl_config) }
-
-
+  let(:url_crawl_result) do
+    double('UrlCrawlResult', status_code: 200, content_type: 'text/html', duration: 0.5, location: nil, error: nil,
+                             suggestion_message: nil)
+  end
+  let(:url_crawl_result_redirect) do
+    instance_double('Crawler::Data::CrawlResult::Redirect',
+                    redirect?: true,
+                    location: Crawler::Data::URL.parse('http://redirected.com'))
+  end
+  let(:validator) { described_class.new(url: valid_url, crawl_config:) }
 
   describe '#validate_url_request' do
     before do
@@ -25,7 +30,11 @@ RSpec.describe(Crawler::UrlValidator) do
 
     context 'when the status code is 200' do
       it 'validates successfully' do
-        expect(validator).to receive(:validation_ok).with(:url_request, "Successfully fetched #{valid_url}: HTTP 200.", hash_including(:status_code, :content_type, :request_time_msec))
+        expect(validator)
+          .to receive(:validation_ok)
+          .with(:url_request,
+                "Successfully fetched #{valid_url}: HTTP 200.",
+                hash_including(:status_code, :content_type, :request_time_msec))
         validator.validate_url_request
       end
     end
@@ -34,7 +43,11 @@ RSpec.describe(Crawler::UrlValidator) do
       before { allow(url_crawl_result).to receive(:status_code).and_return(204) }
 
       it 'fails validation with no content message' do
-        expect(validator).to receive(:validation_fail).with(:url_request, "The Web server at #{valid_url} returned no content (HTTP 204).", hash_including(:status_code, :content_type, :request_time_msec))
+        expect(validator)
+          .to receive(:validation_fail)
+          .with(:url_request,
+                "The Web server at #{valid_url} returned no content (HTTP 204).",
+                hash_including(:status_code, :content_type, :request_time_msec))
         validator.validate_url_request
       end
     end
@@ -43,7 +56,8 @@ RSpec.describe(Crawler::UrlValidator) do
       before { allow(url_crawl_result).to receive(:status_code).and_return(301) }
 
       it 'calls redirect_validation_result' do
-        expect(validator).to receive(:redirect_validation_result).with(hash_including(:status_code, :content_type, :request_time_msec))
+        expect(validator).to receive(:redirect_validation_result)
+          .with(hash_including(:status_code, :content_type, :request_time_msec))
         validator.validate_url_request
       end
     end
@@ -52,7 +66,8 @@ RSpec.describe(Crawler::UrlValidator) do
       before { allow(url_crawl_result).to receive(:status_code).and_return(401) }
 
       it 'calls unauthorized_validation_result' do
-        expect(validator).to receive(:unauthorized_validation_result).with(hash_including(:status_code, :content_type, :request_time_msec))
+        expect(validator).to receive(:unauthorized_validation_result)
+          .with(hash_including(:status_code, :content_type, :request_time_msec))
         validator.validate_url_request
       end
     end
@@ -63,7 +78,12 @@ RSpec.describe(Crawler::UrlValidator) do
       it 'fails validation with forbidden message' do
         expect(validator)
           .to receive(:validation_fail)
-                .with(:url_request, "The web server at #{valid_url} denied us permission to view that page (HTTP 403).\nThis website may require a user name and password.\nRead more at: https://www.elastic.co/guide/en/enterprise-search/current/crawler-managing.html#crawler-managing-authentication.\n", hash_including(:status_code, :content_type, :request_time_msec))
+          .with(:url_request,
+                "The web server at #{valid_url} denied us permission to view that page (HTTP 403).\nThis website " \
+                "may require a user name and password.\nRead more at: " \
+                'https://www.elastic.co/guide/en/enterprise-search/current/crawler-managing.html' \
+                "#crawler-managing-authentication.\n",
+                hash_including(:status_code, :content_type, :request_time_msec))
         validator.validate_url_request
       end
     end
@@ -74,7 +94,9 @@ RSpec.describe(Crawler::UrlValidator) do
       it 'fails validation with not found message' do
         expect(validator)
           .to receive(:validation_fail)
-                .with(:url_request, "The web server at #{valid_url} says that there is no web page at that location (HTTP 404).\n", hash_including(:status_code, :content_type, :request_time_msec))
+          .with(:url_request,
+                "The web server at #{valid_url} says that there is no web page at that location (HTTP 404).\n",
+                hash_including(:status_code, :content_type, :request_time_msec))
         validator.validate_url_request
       end
     end
@@ -83,7 +105,13 @@ RSpec.describe(Crawler::UrlValidator) do
       before { allow(url_crawl_result).to receive(:status_code).and_return(407) }
 
       it 'fails validation with proxy authentication required message' do
-        expect(validator).to receive(:validation_fail).with(:url_request, "The web server at #{valid_url} is configured to require an HTTP proxy for access (HTTP 407).\nThis may mean that you're trying to index an internal (intranet) server.\nRead more at: https://www.elastic.co/guide/en/enterprise-search/current/crawler-private-network-cloud.html.\n", hash_including(:status_code, :content_type, :request_time_msec))
+        expect(validator)
+          .to receive(:validation_fail)
+          .with(:url_request,
+                "The web server at #{valid_url} is configured to require an HTTP proxy for access (HTTP 407).\n" \
+                "This may mean that you're trying to index an internal (intranet) server.\nRead more at: " \
+                "https://www.elastic.co/guide/en/enterprise-search/current/crawler-private-network-cloud.html.\n",
+                hash_including(:status_code, :content_type, :request_time_msec))
         validator.validate_url_request
       end
     end
@@ -92,7 +120,11 @@ RSpec.describe(Crawler::UrlValidator) do
       before { allow(url_crawl_result).to receive(:status_code).and_return(429) }
 
       it 'fails validation with rate limiting message' do
-        expect(validator).to receive(:validation_fail).with(:url_request, "The web server at #{valid_url} refused our connection due to request\nrate-limiting (HTTP 429).\n", hash_including(:status_code, :content_type, :request_time_msec))
+        expect(validator)
+          .to receive(:validation_fail)
+          .with(:url_request,
+                "The web server at #{valid_url} refused our connection due to request\nrate-limiting (HTTP 429).\n",
+                hash_including(:status_code, :content_type, :request_time_msec))
         validator.validate_url_request
       end
     end
@@ -101,7 +133,11 @@ RSpec.describe(Crawler::UrlValidator) do
       before { allow(url_crawl_result).to receive(:status_code).and_return(451) }
 
       it 'fails validation with legal reasons message' do
-        expect(validator).to receive(:validation_fail).with(:url_request, "The web server at #{valid_url} refused our connection due to legal reasons (HTTP 451).\n", hash_including(:status_code, :content_type, :request_time_msec))
+        expect(validator)
+          .to receive(:validation_fail)
+          .with(:url_request,
+                "The web server at #{valid_url} refused our connection due to legal reasons (HTTP 451).\n",
+                hash_including(:status_code, :content_type, :request_time_msec))
         validator.validate_url_request
       end
     end
@@ -110,7 +146,11 @@ RSpec.describe(Crawler::UrlValidator) do
       before { allow(url_crawl_result).to receive(:status_code).and_return(418) }
 
       it 'fails validation with client error message' do
-        expect(validator).to receive(:validation_fail).with(:url_request, "Failed to fetch #{valid_url}: HTTP 418.", hash_including(:status_code, :content_type, :request_time_msec))
+        expect(validator)
+          .to receive(:validation_fail)
+          .with(:url_request,
+                "Failed to fetch #{valid_url}: HTTP 418.",
+                hash_including(:status_code, :content_type, :request_time_msec))
         validator.validate_url_request
       end
     end
@@ -119,7 +159,11 @@ RSpec.describe(Crawler::UrlValidator) do
       before { allow(url_crawl_result).to receive(:status_code).and_return(500) }
 
       it 'fails validation with server error message' do
-        expect(validator).to receive(:validation_fail).with(:url_request, "Transient error fetching #{valid_url}: HTTP 500.", hash_including(:status_code, :content_type, :request_time_msec))
+        expect(validator)
+          .to receive(:validation_fail)
+          .with(:url_request,
+                "Transient error fetching #{valid_url}: HTTP 500.",
+                hash_including(:status_code, :content_type, :request_time_msec))
         validator.validate_url_request
       end
     end
@@ -130,7 +174,11 @@ RSpec.describe(Crawler::UrlValidator) do
       before { allow(url_crawl_result).to receive(:suggestion_message).and_return('Some suggestion') }
 
       it 'fails validation with unexpected error message' do
-        expect(validator).to receive(:validation_fail).with(:url_request, "Unexpected error fetching #{valid_url}: Some error.\nSome suggestion\n", hash_including(:status_code, :content_type, :request_time_msec))
+        expect(validator)
+          .to receive(:validation_fail)
+          .with(:url_request,
+                "Unexpected error fetching #{valid_url}: Some error.\nSome suggestion\n",
+                hash_including(:status_code, :content_type, :request_time_msec))
         validator.validate_url_request
       end
     end
@@ -139,11 +187,13 @@ RSpec.describe(Crawler::UrlValidator) do
       before { allow(url_crawl_result).to receive(:status_code).and_return(999) }
 
       it 'fails validation with unexpected status message' do
-        expect(validator).to receive(:validation_fail).with(:url_request, "Unexpected HTTP status while fetching #{valid_url}: HTTP 999.\n", hash_including(:status_code, :content_type, :request_time_msec))
+        expect(validator)
+          .to receive(:validation_fail)
+          .with(:url_request,
+                "Unexpected HTTP status while fetching #{valid_url}: HTTP 999.\n",
+                hash_including(:status_code, :content_type, :request_time_msec))
         validator.validate_url_request
       end
     end
   end
-
-
 end

--- a/spec/lib/crawler/url_validator_spec.rb
+++ b/spec/lib/crawler/url_validator_spec.rb
@@ -9,17 +9,17 @@
 RSpec.describe(Crawler::UrlValidator) do
   let(:valid_url) { 'http://example.com' }
   let(:domain_allowlist) { ['example.com'] }
-  let(:crawl_config) { double('CrawlConfig', domain_allowlist: domain_allowlist) }
-  let(:validator) { described_class.new(url: valid_url, crawl_config: crawl_config) }
+  let(:crawl_config) { double('CrawlConfig', domain_allowlist:) }
+  let(:validator) { described_class.new(url: valid_url, crawl_config:) }
 
   describe '#initialize' do
     context 'when crawl_config has no domain_allowlist' do
       let(:crawl_config) { double('CrawlConfig', domain_allowlist: []) }
 
       it 'raises an InvalidCrawlConfigError' do
-        expect {
-          described_class.new(url: valid_url, crawl_config: crawl_config)
-        }.to raise_error(Crawler::UrlValidator::InvalidCrawlConfigError)
+        expect do
+          described_class.new(url: valid_url, crawl_config:)
+        end.to raise_error(Crawler::UrlValidator::InvalidCrawlConfigError)
       end
     end
 
@@ -64,7 +64,7 @@ RSpec.describe(Crawler::UrlValidator) do
 
   describe '#validate' do
     it 'performs all checks and populates the results array' do
-      allow(validator).to receive(:perform_check) do |check_name|
+      allow(validator).to receive(:perform_check) do |_check_name|
         validator.results << double('Result', failure?: false)
       end
       validator.validate
@@ -74,7 +74,7 @@ RSpec.describe(Crawler::UrlValidator) do
 
   describe '#url' do
     it 'parses the raw_url' do
-      expect(::Crawler::Data::URL).to receive(:parse).with(valid_url)
+      expect(Crawler::Data::URL).to receive(:parse).with(valid_url)
       validator.url
     end
   end
@@ -154,11 +154,10 @@ RSpec.describe(Crawler::UrlValidator) do
 
     context 'when the check method does not exist' do
       it 'raises an ArgumentError' do
-        expect {
+        expect do
           validator.send(:perform_check, 'x')
-        }.to raise_error(ArgumentError, 'Invalid check name: "x"')
+        end.to raise_error(ArgumentError, 'Invalid check name: "x"')
       end
     end
   end
-
 end

--- a/spec/lib/crawler/url_validator_spec.rb
+++ b/spec/lib/crawler/url_validator_spec.rb
@@ -1,0 +1,158 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+
+RSpec.describe Crawler::UrlValidator do
+  let(:valid_url) { 'http://example.com' }
+  let(:invalid_url) { 'invalid_url' }
+  let(:crawl_config) { double('CrawlConfig', domain_allowlist: ['example.com']) }
+  let(:validator) { described_class.new(url: valid_url, crawl_config: crawl_config) }
+
+  describe '#initialize' do
+    context 'when crawl_config has no domain_allowlist' do
+      let(:crawl_config) { double('CrawlConfig', domain_allowlist: []) }
+
+      it 'raises an InvalidCrawlConfigError' do
+        expect { described_class.new(url: valid_url, crawl_config: crawl_config) }.to raise_error(Crawler::UrlValidator::InvalidCrawlConfigError)
+      end
+    end
+
+    context 'when valid parameters are provided' do
+      it 'initializes with the correct attributes' do
+        expect(validator.raw_url).to eq(valid_url)
+        expect(validator.checks).to include(:url)
+        expect(validator.results).to be_empty
+      end
+    end
+  end
+
+  describe '#valid_checks' do
+    it 'returns the domain level checks' do
+      expect(validator.valid_checks).to eq(Crawler::UrlValidator::DOMAIN_LEVEL_CHECKS)
+    end
+  end
+
+  describe '#valid?' do
+    context 'when all checks pass' do
+      before do
+        allow(validator).to receive(:validate).and_return(true)
+        allow(validator).to receive(:any_failed_results?).and_return(false)
+      end
+
+      it 'returns true' do
+        expect(validator.valid?).to be true
+      end
+    end
+
+    context 'when any check fails' do
+      before do
+        allow(validator).to receive(:validate).and_return(true)
+        allow(validator).to receive(:any_failed_results?).and_return(true)
+      end
+
+      it 'returns false' do
+        expect(validator.valid?).to be false
+      end
+    end
+  end
+
+  describe '#validate' do
+    it 'performs all checks and populates the results array' do
+      allow(validator).to receive(:perform_check) do |check_name|
+        validator.results << double('Result', failure?: false)
+      end
+      validator.validate
+      expect(validator.results).not_to be_empty
+    end
+  end
+
+  describe '#url' do
+    it 'parses the raw_url' do
+      expect(::Crawler::Data::URL).to receive(:parse).with(valid_url)
+      validator.url
+    end
+  end
+
+  describe '#normalized_url' do
+    context 'when the URL is valid' do
+      it 'returns the normalized URL' do
+        parsed_url = double('URL', normalized_url: 'http://example.com/')
+        allow(validator).to receive(:url).and_return(parsed_url)
+        expect(validator.normalized_url).to eq('http://example.com/')
+      end
+    end
+
+    context 'when the URL is invalid' do
+      it 'returns the raw_url' do
+        allow(validator).to receive(:url).and_raise(Addressable::URI::InvalidURIError)
+        expect(validator.normalized_url).to eq(valid_url)
+      end
+    end
+  end
+
+  describe '#failed_checks' do
+    it 'returns the failed checks' do
+      failed_result = double('Result', failure?: true)
+      allow(validator).to receive(:results).and_return([failed_result])
+      expect(validator.failed_checks).to include(failed_result)
+    end
+  end
+
+  describe '#validation_ok' do
+    it 'adds a successful result to the results array' do
+      validator.send(:validation_ok, 'test_check', 'All good')
+      expect(validator.results.last.result).to eq(:ok)
+      expect(validator.results.last.comment).to eq('All good')
+    end
+  end
+
+  describe '#validation_warn' do
+    it 'adds a warning result to the results array' do
+      validator.send(:validation_warn, 'test_check', 'Something might be wrong')
+      expect(validator.results.last.result).to eq(:warning)
+      expect(validator.results.last.comment).to eq('Something might be wrong')
+    end
+  end
+
+  describe '#validation_fail' do
+    it 'adds a failure result to the results array' do
+      validator.send(:validation_fail, 'test_check', 'Something went wrong')
+      expect(validator.results.last.result).to eq(:failure)
+      expect(validator.results.last.comment).to eq('Something went wrong')
+    end
+  end
+
+  describe '#perform_check' do
+    before do
+      # Define a temporary method for testing
+      Crawler::UrlValidator.class_eval do
+        private
+
+        def validate_test_check
+          validation_ok('test_check', 'Test check passed')
+        end
+      end
+    end
+
+    after do
+      # Remove the temporary method after testing
+      Crawler::UrlValidator.send(:remove_method, :validate_test_check)
+    end
+
+    context 'when the check method exists' do
+      it 'calls the check method' do
+        expect(validator).to receive(:validate_test_check).and_call_original
+        validator.send(:perform_check, 'test_check')
+      end
+    end
+
+    context 'when the check method does not exist' do
+      it 'raises an ArgumentError' do
+        expect { validator.send(:perform_check, 'non_existent_check') }.to raise_error(ArgumentError, 'Invalid check name: "non_existent_check"')
+      end
+    end
+  end
+
+end

--- a/spec/lib/crawler/url_validator_spec.rb
+++ b/spec/lib/crawler/url_validator_spec.rb
@@ -4,10 +4,12 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 
-RSpec.describe Crawler::UrlValidator do
+# frozen_string_literal: true
+
+RSpec.describe(Crawler::UrlValidator) do
   let(:valid_url) { 'http://example.com' }
-  let(:invalid_url) { 'invalid_url' }
-  let(:crawl_config) { double('CrawlConfig', domain_allowlist: ['example.com']) }
+  let(:domain_allowlist) { ['example.com'] }
+  let(:crawl_config) { double('CrawlConfig', domain_allowlist: domain_allowlist) }
   let(:validator) { described_class.new(url: valid_url, crawl_config: crawl_config) }
 
   describe '#initialize' do
@@ -15,7 +17,9 @@ RSpec.describe Crawler::UrlValidator do
       let(:crawl_config) { double('CrawlConfig', domain_allowlist: []) }
 
       it 'raises an InvalidCrawlConfigError' do
-        expect { described_class.new(url: valid_url, crawl_config: crawl_config) }.to raise_error(Crawler::UrlValidator::InvalidCrawlConfigError)
+        expect {
+          described_class.new(url: valid_url, crawl_config: crawl_config)
+        }.to raise_error(Crawler::UrlValidator::InvalidCrawlConfigError)
       end
     end
 
@@ -150,7 +154,9 @@ RSpec.describe Crawler::UrlValidator do
 
     context 'when the check method does not exist' do
       it 'raises an ArgumentError' do
-        expect { validator.send(:perform_check, 'non_existent_check') }.to raise_error(ArgumentError, 'Invalid check name: "non_existent_check"')
+        expect {
+          validator.send(:perform_check, 'x')
+        }.to raise_error(ArgumentError, 'Invalid check name: "x"')
       end
     end
   end


### PR DESCRIPTION
This is a ad-hoc/trivial change. By reading the [test section in contribution](https://github.com/elastic/crawler/blob/main/docs/CONTRIBUTING.md#testing) found out the intended coverage is 92% of code. While building locally and running the tests found out the url validator related code test coverage could increase and decided to contribute with few rspec tests.  Please let me know if the changes are in alignment with expectations in relation to code style. 

---

Current coverage: 

![Screenshot 2024-12-02 at 10 24 27](https://github.com/user-attachments/assets/35d69770-d50f-4984-9e2b-bffd34bc937b)

Coverage after new tests:

![Screenshot 2024-12-02 at 10 24 02](https://github.com/user-attachments/assets/3d436c10-df85-40bc-aacf-4cc7dad516dd)

---

### Checklists

#### Pre-Review Checklist
- [X] This PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `crawler.yml.example` and `elasticsearch.yml.example`)
- [X] This PR has a meaningful title
- [X] this PR has a thorough description
- [X] Covered the changes with automated tests
- [X] Tested the changes locally
