### PR TITLE
Make elasticsearch the default value for output_sink

### DIFF
--- a/lib/crawler/api/config.rb
+++ b/lib/crawler/api/config.rb
@@ -169,7 +169,7 @@ module Crawler
         binary_content_extraction_enabled: false,
         binary_content_extraction_mime_types: [],
 
-        output_sink: :console,
+        output_sink: :elasticsearch,
         url_queue: :memory_only,
         threads_per_crawl: 10,
 

--- a/spec/lib/crawler/api/config_spec.rb
+++ b/spec/lib/crawler/api/config_spec.rb
@@ -30,15 +30,15 @@ RSpec.describe(Crawler::API::Config) do
       end.to raise_error(ArgumentError, /Unexpected configuration options.*fubar/)
     end
 
-    it 'can define a crawl with elasticsearch output' do
+    it 'can define a crawl with console output' do
       config = Crawler::API::Config.new(
         domains:,
-        output_sink: :elasticsearch
+        output_sink: :console
       )
 
       expect(config.domain_allowlist.map(&:to_s)).to match_array(expected_allowlist)
       expect(config.seed_urls.map(&:to_s).to_a).to match_array(expected_seed_urls)
-      expect(config.output_sink).to eq(:elasticsearch)
+      expect(config.output_sink).to eq(:console)
       expect(config.output_dir).to be_nil
     end
 
@@ -62,7 +62,7 @@ RSpec.describe(Crawler::API::Config) do
 
       expect(config.domain_allowlist.map(&:to_s)).to match_array(expected_allowlist)
       expect(config.seed_urls.map(&:to_s).to_a).to match_array(expected_seed_urls)
-      expect(config.output_sink).to eq(:console)
+      expect(config.output_sink).to eq(:elasticsearch)
       expect(config.output_dir).to be_nil
     end
 

--- a/spec/lib/crawler/api/crawl_spec.rb
+++ b/spec/lib/crawler/api/crawl_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe(Crawler::API::Crawl) do
   let(:crawl_config) do
     Crawler::API::Config.new(
       domains: [
-        { url: url }
+        { url: }
       ],
       output_sink: :elasticsearch,
       output_index: 'some-index-name',

--- a/spec/lib/crawler/api/crawl_spec.rb
+++ b/spec/lib/crawler/api/crawl_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe(Crawler::API::Crawl) do
   let(:crawl_config) do
     Crawler::API::Config.new(
       domains: [
-        { url: url}
+        { url: url }
       ],
       output_sink: :elasticsearch,
       output_index: 'some-index-name',
@@ -22,7 +22,6 @@ RSpec.describe(Crawler::API::Crawl) do
         port: 1234,
         api_key: 'key'
       }
-
     )
   end
 

--- a/spec/lib/crawler/api/crawl_spec.rb
+++ b/spec/lib/crawler/api/crawl_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe(Crawler::API::Crawl) do
   #-------------------------------------------------------------------------------------------------
   it 'has a config' do
     expect(subject.config.seed_urls.map(&:to_s).to_a).to eq(["#{url}/"])
-    expect(subject.config.output_sink).to eq(:console)
+    expect(subject.config.output_sink).to eq(:elasticsearch)
   end
 
   it 'has a output sink' do

--- a/spec/lib/crawler/api/crawl_spec.rb
+++ b/spec/lib/crawler/api/crawl_spec.rb
@@ -13,8 +13,16 @@ RSpec.describe(Crawler::API::Crawl) do
   let(:crawl_config) do
     Crawler::API::Config.new(
       domains: [
-        { url: }
-      ]
+        { url: url}
+      ],
+      output_sink: :elasticsearch,
+      output_index: 'some-index-name',
+      elasticsearch: {
+        host: 'http://localhost',
+        port: 1234,
+        api_key: 'key'
+      }
+
     )
   end
 

--- a/spec/lib/crawler/coordinator_spec.rb
+++ b/spec/lib/crawler/coordinator_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe(Crawler::Coordinator) do
         {
           domains:,
           results_collection:,
-          output_sink: 'console',
+          output_sink: 'elasticsearch',
           purge_crawl_enabled: true
         }
       end

--- a/spec/lib/crawler/coordinator_spec.rb
+++ b/spec/lib/crawler/coordinator_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe(Crawler::Coordinator) do
         {
           domains:,
           results_collection:,
-          output_sink: 'elasticsearch',
+          output_sink: :console,
           purge_crawl_enabled: true
         }
       end

--- a/spec/lib/crawler/output_sink_spec.rb
+++ b/spec/lib/crawler/output_sink_spec.rb
@@ -24,11 +24,18 @@ RSpec.describe(Crawler::OutputSink) do
     it 'should return a new sink object of a correct type' do
       config = Crawler::API::Config.new(
         domains:,
-        output_sink: 'elasticsearch'
+        output_sink: :elasticsearch,
+        output_index: 'some-index-name',
+        elasticsearch: {
+          host: 'http://localhost',
+          port: 1234,
+          api_key: 'key'
+        }
+
       )
 
       sink = Crawler::OutputSink.create(config)
-      expect(sink).to be_kind_of(Crawler::OutputSink::Console)
+      expect(sink).to be_kind_of(Crawler::OutputSink::Elasticsearch)
     end
   end
 end

--- a/spec/lib/crawler/output_sink_spec.rb
+++ b/spec/lib/crawler/output_sink_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe(Crawler::OutputSink) do
           port: 1234,
           api_key: 'key'
         }
-
       )
 
       sink = Crawler::OutputSink.create(config)

--- a/spec/lib/crawler/output_sink_spec.rb
+++ b/spec/lib/crawler/output_sink_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe(Crawler::OutputSink) do
     it 'should return a new sink object of a correct type' do
       config = Crawler::API::Config.new(
         domains:,
-        output_sink: 'console'
+        output_sink: 'elasticsearch'
       )
 
       sink = Crawler::OutputSink.create(config)


### PR DESCRIPTION
Issue #174 , 
I have replaced console with elasticsearch. Please let me know if any other changes are needed.

### Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] This PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `crawler.yml.example` and `elasticsearch.yml.example`)
- [x] This PR has a meaningful title
- [x] This PR links to all relevant GitHub issues that it fixes or partially addresses
    - If there is no GitHub issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description

