### PR TITLE
Fixes #179 - Omits the pipeline key when pipeline_enabled: false

### DIFF
--- a/lib/crawler/output_sink/elasticsearch.rb
+++ b/lib/crawler/output_sink/elasticsearch.rb
@@ -129,7 +129,9 @@ module Crawler
         system_logger.info("Sending bulk request with #{indexing_docs_count} items and resetting queue...")
 
         begin
-          client.bulk(body:, pipeline:) # TODO: parse response
+          client.bulk(
+            **{ body: body }.merge(pipeline_enabled? ? { pipeline: pipeline } : {})
+          ) # TODO: parse response
           system_logger.info("Successfully indexed #{indexing_docs_count} docs.")
           reset_ingestion_stats(true)
         rescue ES::Client::IndexingFailedError => e

--- a/lib/crawler/output_sink/elasticsearch.rb
+++ b/lib/crawler/output_sink/elasticsearch.rb
@@ -130,7 +130,7 @@ module Crawler
 
         begin
           client.bulk(
-            **{ body: body }.merge(pipeline_enabled? ? { pipeline: pipeline } : {})
+            body:, **(pipeline_enabled? ? { pipeline: } : {})
           ) # TODO: parse response
           system_logger.info("Successfully indexed #{indexing_docs_count} docs.")
           reset_ingestion_stats(true)

--- a/spec/lib/crawler/output_sink/elasticsearch_spec.rb
+++ b/spec/lib/crawler/output_sink/elasticsearch_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
       end
     end
 
-    context 'when elasticsearch.pipeline is not provided' do
+    context 'when elasticsearch.pipeline is provided' do
       let(:config) do
         Crawler::API::Config.new(
           domains:,

--- a/spec/lib/crawler/output_sink/elasticsearch_spec.rb
+++ b/spec/lib/crawler/output_sink/elasticsearch_spec.rb
@@ -120,11 +120,34 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
         )
       end
 
-      it 'uses the default pipeline' do
+      it 'uses the specified pipeline' do
         expect { subject }.not_to raise_error
         expect(subject.pipeline).to eq('my-pipeline')
         expect(system_logger).to have_received(:info).with(
           "Elasticsearch sink initialized for index [#{index_name}] with pipeline [my-pipeline]"
+        )
+      end
+    end
+
+    context 'when elasticsearch.pipeline is not provided' do
+      let(:config) do
+        Crawler::API::Config.new(
+          domains:,
+          output_sink: 'elasticsearch',
+          output_index: index_name,
+          elasticsearch: {
+            host: 'http://localhost',
+            port: 1234,
+            api_key: 'key'
+          }
+        )
+      end
+
+      it 'uses the default pipeline' do
+        expect { subject }.not_to raise_error
+        expect(subject.pipeline).to eq('ent-search-generic-ingestion')
+        expect(system_logger).to have_received(:info).with(
+          "Elasticsearch sink initialized for index [#{index_name}] with pipeline [ent-search-generic-ingestion]"
         )
       end
     end
@@ -178,10 +201,13 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
         )
       end
 
-      it 'overrides the specified default params and includes new ones' do
+      it 'overrides the specified default params' do
         expect { subject }.not_to raise_error
         expect(subject.pipeline_enabled?).to eq(false)
+        expect(subject.pipeline).to eq(nil)
       end
+
+
     end
   end
 

--- a/spec/lib/crawler/output_sink/elasticsearch_spec.rb
+++ b/spec/lib/crawler/output_sink/elasticsearch_spec.rb
@@ -206,8 +206,6 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
         expect(subject.pipeline_enabled?).to eq(false)
         expect(subject.pipeline).to eq(nil)
       end
-
-
     end
   end
 


### PR DESCRIPTION
### Closes https://github.com/elastic/crawler/issues/179

Fixes empty pipeline param being sent when pipelines are disabled.
