### PR TITLE
Adding check to ES sink to check if index is present before crawling

### DIFF
--- a/lib/crawler/output_sink/elasticsearch.rb
+++ b/lib/crawler/output_sink/elasticsearch.rb
@@ -44,12 +44,8 @@ module Crawler
       end
 
       def ping_output_index
-        # when the index is not found, indices.get() fails in an 'ugly' way.
-        # rescue, log, then raise a SystemExit to make termination more graceful
-        client.indices.get(index: config.output_index)
-      rescue StandardError
-        system_logger.info("Failed to find index #{config.output_index}, aborting")
-        raise SystemExit
+        raise Errors::IndexDoesNotExistError, system_logger.info("Failed to find index #{config.output_index}") unless
+          client.indices.exists(index: config.output_index)
       end
 
       def write(crawl_result)

--- a/lib/errors.rb
+++ b/lib/errors.rb
@@ -18,4 +18,10 @@ class Errors
   # overloading the queue if Elasticsearch indexing is failing repeatedly and performing
   # exponential backoff. This error should be treated as retryable.
   class SinkLockedError < StandardError; end
+
+  # Raised when the desired output index does not exist. This is specific for Elasticsearch
+  # sink. During initialization of the Elasticsearch sink, it will call indices.exists()
+  # against the output_index value, and will continue if the index is found.
+  # If it is not found, this error will be raised, which causes a system exit to occur.
+  class IndexDoesNotExistError < SystemExit; end
 end

--- a/spec/lib/crawler/api/crawl_spec.rb
+++ b/spec/lib/crawler/api/crawl_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe(Crawler::API::Crawl) do
   let(:executor) { Crawler::MockExecutor.new(url => mock_crawl_result) }
 
   let(:es_client) { double }
-  let(:es_client_indices) { double(:es_client_indices, get: double) }
+  let(:es_client_indices) { double(:es_client_indices, exists: double) }
 
   subject do
     described_class.new(crawl_config).tap do |crawl|

--- a/spec/lib/crawler/api/crawl_spec.rb
+++ b/spec/lib/crawler/api/crawl_spec.rb
@@ -34,6 +34,9 @@ RSpec.describe(Crawler::API::Crawl) do
   end
   let(:executor) { Crawler::MockExecutor.new(url => mock_crawl_result) }
 
+  let(:es_client) { double }
+  let(:es_client_indices) { double(:es_client_indices, get: double) }
+
   subject do
     described_class.new(crawl_config).tap do |crawl|
       crawl.executor = executor
@@ -43,6 +46,9 @@ RSpec.describe(Crawler::API::Crawl) do
   before do
     # Replace the event logger with a fake one to capture logged events
     crawl_config.instance_variable_set(:@event_logger, Crawler::MockEventLogger.new)
+
+    allow(ES::Client).to receive(:new).and_return(es_client)
+    allow(es_client).to receive(:indices).and_return(es_client_indices)
   end
 
   #-------------------------------------------------------------------------------------------------

--- a/spec/lib/crawler/coordinator_spec.rb
+++ b/spec/lib/crawler/coordinator_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe(Crawler::Coordinator) do
       allow(es_client).to receive(:delete_by_query).and_return({ deleted: 1 }.stringify_keys)
       allow(es_client)
         .to receive(:paginated_search).and_return([search_result])
-      allow(es_client).to receive(:indices).and_return(double(:indices, refresh: double))
+      allow(es_client).to receive(:indices).and_return(double(:indices, refresh: double, get: double))
 
       allow(sink).to receive(:purge).and_call_original
       allow(crawl_result).to receive(:extract_links).and_return(double)

--- a/spec/lib/crawler/coordinator_spec.rb
+++ b/spec/lib/crawler/coordinator_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe(Crawler::Coordinator) do
       allow(es_client).to receive(:delete_by_query).and_return({ deleted: 1 }.stringify_keys)
       allow(es_client)
         .to receive(:paginated_search).and_return([search_result])
-      allow(es_client).to receive(:indices).and_return(double(:indices, refresh: double, get: double))
+      allow(es_client).to receive(:indices).and_return(double(:indices, refresh: double, exists: double))
 
       allow(sink).to receive(:purge).and_call_original
       allow(crawl_result).to receive(:extract_links).and_return(double)

--- a/spec/lib/crawler/output_sink/elasticsearch_spec.rb
+++ b/spec/lib/crawler/output_sink/elasticsearch_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
   let(:default_pipeline_params) { Crawler::OutputSink::Elasticsearch::DEFAULT_PIPELINE_PARAMS }
   let(:system_logger) { double }
   let(:es_client) { double }
-  let(:es_client_indices) { double(:es_client_indices, refresh: double) }
+  let(:es_client_indices) { double(:es_client_indices, refresh: double, get: double) }
   let(:bulk_queue) { double }
   let(:serializer) { double }
 
@@ -86,6 +86,29 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
 
       it 'raises an ArgumentError' do
         expect { subject }.to raise_error(ArgumentError, /Missing elasticsearch configuration/)
+      end
+    end
+
+    context 'when output index is provided but index does not exist in ES' do
+      before(:each) do
+        allow(es_client_indices).to receive(:get).and_raise(StandardError)
+      end
+
+      it 'raises a SystemExit' do
+        expect { subject.ping_output_index }.to raise_error(SystemExit)
+        expect(system_logger).to have_received(:info).with(
+          "Failed to find index #{index_name}, aborting"
+        )
+      end
+    end
+
+    context 'when output index is provided and index exists in ES' do
+      before(:each) do
+        allow(es_client).to receive(:get).and_return({ "some": "response" })
+      end
+
+      it 'does not raise an error' do
+        expect { subject.ping_output_index }.not_to raise_error
       end
     end
 

--- a/spec/lib/crawler/output_sink/elasticsearch_spec.rb
+++ b/spec/lib/crawler/output_sink/elasticsearch_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
 
     context 'when output index is provided and index exists in ES' do
       before(:each) do
-        allow(es_client).to receive(:get).and_return({ "some": "response" })
+        allow(es_client).to receive(:get).and_return({ 'some' => 'response' })
       end
 
       it 'does not raise an error' do

--- a/spec/lib/crawler/output_sink_spec.rb
+++ b/spec/lib/crawler/output_sink_spec.rb
@@ -9,6 +9,14 @@
 RSpec.describe(Crawler::OutputSink) do
   let(:domains) { [{ url: 'http://example.com' }] }
 
+  let(:es_client) { double }
+  let(:es_client_indices) { double(:es_client_indices, get: double) }
+
+  before(:each) do
+    allow(ES::Client).to receive(:new).and_return(es_client)
+    allow(es_client).to receive(:indices).and_return(es_client_indices)
+  end
+
   context '.create' do
     it 'should validate the sync name' do
       config = Crawler::API::Config.new(

--- a/spec/lib/crawler/output_sink_spec.rb
+++ b/spec/lib/crawler/output_sink_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe(Crawler::OutputSink) do
   let(:domains) { [{ url: 'http://example.com' }] }
 
   let(:es_client) { double }
-  let(:es_client_indices) { double(:es_client_indices, get: double) }
+  let(:es_client_indices) { double(:es_client_indices, exists: double) }
 
   before(:each) do
     allow(ES::Client).to receive(:new).and_return(es_client)


### PR DESCRIPTION
### Closes https://github.com/elastic/crawler/issues/53
This PR aims to add a check during the initialization phase of the Elasticsearch output sink that will:

1. Check if the the ES index provided in the config is reachable by Open Crawler
2. Terminate if it is not
3. Output a relevant log message

Ultimately, we do not want the crawl to begin without making sure the index is actually reachable first!

### Checklists

#### Pre-Review Checklist
- [x] This PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `crawler.yml.example` and `elasticsearch.yml.example`)
- [x] This PR has a meaningful title
- [x] This PR links to all relevant GitHub issues that it fixes or partially addresses
    - If there is no GitHub issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v0.1.0`)
