### PR TITLE
Adding ES verification step + explicit best-effort index creation during ES Sink initialization

### DIFF
--- a/lib/crawler/output_sink/elasticsearch.rb
+++ b/lib/crawler/output_sink/elasticsearch.rb
@@ -49,7 +49,7 @@ module Crawler
         client.info
       rescue Elastic::Transport::Transport::Error # rescue bc client.info crashes ungracefully when ES is unreachable
         system_logger.info("Failed to reach #{config.elasticsearch[:host]}:#{config.elasticsearch[:port]}")
-        raise Errors::ESConnectionError
+        raise Errors::ExitIfESConnectionError
       end
 
       def verify_output_index
@@ -63,7 +63,7 @@ module Crawler
 
       def attempt_index_creation_or_exit
         # helper method for verify_output_index
-        raise Errors::UnableToCreateIndex, system_logger.info("Failed to create #{config.output_index}") unless
+        raise Errors::ExitIfUnableToCreateIndex, system_logger.info("Failed to create #{config.output_index}") unless
           client.indices.create(index: config.output_index)
       end
 

--- a/lib/crawler/output_sink/elasticsearch.rb
+++ b/lib/crawler/output_sink/elasticsearch.rb
@@ -33,8 +33,10 @@ module Crawler
         # initialize client now to fail fast if config is bad
         client
 
-        # ping ES by attempting to reach the index specified in config
-        ping_output_index
+        # ping ES to verify the provided config is good
+        verify_es_connection
+        # ping the output_index provided in the config, and create it if it does not exist
+        verify_output_index
 
         @queue_lock = Mutex.new
         init_ingestion_stats
@@ -43,9 +45,25 @@ module Crawler
         )
       end
 
-      def ping_output_index
-        raise Errors::IndexDoesNotExistError, system_logger.info("Failed to find index #{config.output_index}") unless
-          client.indices.exists(index: config.output_index)
+      def verify_es_connection
+        client.info
+      rescue StandardError # rescue because client.info crashes ungracefully when ES is unreachable
+        system_logger.info("Failed to reach #{config.elasticsearch[:host]}:#{config.elasticsearch[:port]}")
+        raise Errors::ESConnectionError
+      end
+
+      def verify_output_index
+        if client.indices.exists(index: config.output_index) == false
+          create_index # this method will system exit upon failure
+          system_logger.info("Index [#{config.output_index}] did not exist, but was successfully created!")
+        else
+          system_logger.info("Index [#{config.output_index}] was found!")
+        end
+      end
+
+      def create_index
+        raise Errors::UnableToCreateIndex, system_logger.info("Failed to create #{config.output_index}") unless
+          client.indices.create(index: config.output_index)
       end
 
       def write(crawl_result)

--- a/lib/errors.rb
+++ b/lib/errors.rb
@@ -22,11 +22,11 @@ class Errors
   # Raised when there is a connection error to Elasticsearch. Specific for Elasticsearch sink.
   # During initialization of the Elasticsearch sink, it will attempt to make contact to
   # the host provided in the configuration. If contact cannot  be established, a system exit will occur.
-  class ESConnectionError < SystemExit; end
+  class ExitIfESConnectionError < SystemExit; end
 
   # Raised when the desired output index does not exist. This is specific for Elasticsearch
   # sink. During initialization of the Elasticsearch sink, it will call indices.exists()
   # against the output_index value, and will continue if the index is found.
   # If it is not found, this error will be raised, which causes a system exit to occur.
-  class UnableToCreateIndex < SystemExit; end
+  class ExitIfUnableToCreateIndex < SystemExit; end
 end

--- a/lib/errors.rb
+++ b/lib/errors.rb
@@ -19,9 +19,14 @@ class Errors
   # exponential backoff. This error should be treated as retryable.
   class SinkLockedError < StandardError; end
 
+  # Raised when there is a connection error to Elasticsearch. Specific for Elasticsearch sink.
+  # During initialization of the Elasticsearch sink, it will attempt to make contact to
+  # the host provided in the configuration. If contact cannot  be established, a system exit will occur.
+  class ESConnectionError < SystemExit; end
+
   # Raised when the desired output index does not exist. This is specific for Elasticsearch
   # sink. During initialization of the Elasticsearch sink, it will call indices.exists()
   # against the output_index value, and will continue if the index is found.
   # If it is not found, this error will be raised, which causes a system exit to occur.
-  class IndexDoesNotExistError < SystemExit; end
+  class UnableToCreateIndex < SystemExit; end
 end

--- a/spec/lib/crawler/api/crawl_spec.rb
+++ b/spec/lib/crawler/api/crawl_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe(Crawler::API::Crawl) do
 
     allow(ES::Client).to receive(:new).and_return(es_client)
     allow(es_client).to receive(:indices).and_return(es_client_indices)
+    allow(es_client).to receive(:info).and_return(true)
   end
 
   #-------------------------------------------------------------------------------------------------

--- a/spec/lib/crawler/coordinator_spec.rb
+++ b/spec/lib/crawler/coordinator_spec.rb
@@ -84,6 +84,7 @@ RSpec.describe(Crawler::Coordinator) do
     before do
       allow(ES::Client).to receive(:new).and_return(es_client)
       allow(es_client).to receive(:bulk)
+      allow(es_client).to receive(:info).and_return(true)
       allow(es_client).to receive(:delete_by_query).and_return({ deleted: 1 }.stringify_keys)
       allow(es_client)
         .to receive(:paginated_search).and_return([search_result])

--- a/spec/lib/crawler/output_sink/elasticsearch_spec.rb
+++ b/spec/lib/crawler/output_sink/elasticsearch_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
       end
 
       it 'should raise an ESConnectionError' do
-        expect { subject.verify_es_connection }.to raise_error(Errors::ESConnectionError)
+        expect { subject.verify_es_connection }.to raise_error(Errors::ExitIfESConnectionError)
         expect(system_logger).to have_received(:info).with(
           "Failed to reach #{config.elasticsearch[:host]}:#{config.elasticsearch[:port]}"
         )
@@ -129,8 +129,8 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
         allow(es_client_indices).to receive(:create).and_return(false)
       end
 
-      it 'raises UnableToCreateIndex' do
-        expect { subject.create_index }.to raise_error(Errors::UnableToCreateIndex)
+      it 'raises ExitIfUnableToCreateIndex' do
+        expect { subject.attempt_index_creation_or_exit }.to raise_error(Errors::ExitIfUnableToCreateIndex)
         expect(system_logger).to have_received(:info).with(
           "Failed to create #{index_name}"
         )

--- a/spec/lib/crawler/output_sink/elasticsearch_spec.rb
+++ b/spec/lib/crawler/output_sink/elasticsearch_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
 
     context 'when connection to Elasticsearch cannot be established' do
       before(:each) do
-        allow(es_client).to receive(:info).and_raise(StandardError)
+        allow(es_client).to receive(:info).and_raise(Elastic::Transport::Transport::Error)
       end
 
       it 'should raise an ESConnectionError' do
@@ -113,10 +113,10 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
       before(:each) do
         allow(es_client_indices).to receive(:exists).and_return(false)
         allow(es_client_indices).to receive(:create).and_return({ 'some' => 'response' })
+        allow(subject).to receive(:verify_output_index)
       end
 
       it 'should create the index' do
-        expect { subject.create_index }.not_to raise_error
         expect(system_logger).to have_received(:info).with(
           "Index [#{index_name}] did not exist, but was successfully created!"
         )

--- a/spec/lib/crawler/output_sink_spec.rb
+++ b/spec/lib/crawler/output_sink_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe(Crawler::OutputSink) do
   before(:each) do
     allow(ES::Client).to receive(:new).and_return(es_client)
     allow(es_client).to receive(:indices).and_return(es_client_indices)
+    allow(es_client).to receive(:info).and_return(true)
   end
 
   context '.create' do


### PR DESCRIPTION
### Closes https://github.com/elastic/crawler/issues/53 and https://github.com/elastic/crawler/issues/172

This is a continuation of issue #53 but also closes #172.
This PR will add the following steps during the initialization of the ES Sink:
- A verification step that checks if crawler can reach the Elasticsearch instance provided in configs
- An explicit attempt to create the output_index should the index ping fail (index ping step was added in #186 )

Thus, the flow during init will be like:
`verify ES connection`--> `if all good, verify the output_index `--> `if index does not exist, attempt to create the index` --> `if index creation fails, system exit`

Additional background:
While working on this, I discovered that _technically speaking_, the _bulk command that Crawler uses to upsert documents is capable of auto-creating the index if it doesn't exist. However, this is dependent on the user having `auto_configure`, `create_index`, or `manage` index privileges.

Therefore, while we may not _need_ an explicit index creation attempt, it is good to have because we can then explicitly log that it happened, and also provide a safe point to fail out at should something go wrong vs. waiting for _bulk to be called, at which point a crawl would have already begun.

### Checklists

#### Pre-Review Checklist
- [x] This PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `crawler.yml.example` and `elasticsearch.yml.example`)
- [x] This PR has a meaningful title
- [x] This PR links to all relevant GitHub issues that it fixes or partially addresses
    - If there is no GitHub issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v0.1.0`)
- [x] Considered corresponding documentation changes

### Related Pull Requests
https://github.com/elastic/crawler/pull/186
