### PR TITLE
Fix scheduling documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ See an example below for a crawl schedule that will execute once every 30 minute
 domains:
   - url: "https://elastic.co"
 schedule:
-  - pattern: "*/30 * * * *" # run every 30th minute
+  pattern: "*/30 * * * *" # run every 30th minute
 ```
 
 Then, use the CLI to then begin the crawl job schedule:

--- a/config/crawler.yml.example
+++ b/config/crawler.yml.example
@@ -56,7 +56,7 @@
 #
 ## Scheduling using cron expressions
 #schedule:
-#  - pattern: "0 12 * * *"     # every day at noon
+#  pattern: "0 12 * * *"     # every day at noon
 #
 ## Crawl result field size limits
 #max_title_size: 1000


### PR DESCRIPTION
Related to https://github.com/elastic/crawler/issues/195

The `scheduling.pattern` config should be an object, not an array.