### PR TITLE
Update docker files to remove /root/.m2 directory after installation to not distribute build dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,7 @@ COPY . /app
 WORKDIR /app
 RUN make clean install
 
+# Clean up build dependencies
+RUN rm -r /root/.m2
+
 ENTRYPOINT [ "/bin/bash" ]

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -56,6 +56,9 @@ ENV IS_DOCKER=1
 
 RUN make clean install
 
+# Clean up build dependencies
+RUN rm -r /root/.m2
+
 # ------------------------------------------------------------------------------
 # remove now-unnecessary packages and directories
 


### PR DESCRIPTION
Part of security hardening: remove `/root/.m2` directory after the installation has happened.

It seems like it's not needed as it keeps Maven cache, but we already vendor all dependencies on `make install`.

This way we won't distribute any compile-time dependencies, reducing our potential attack surface.