### PR TITLE
Allow for full HTML extraction

### DIFF
--- a/config/crawler.yml.example
+++ b/config/crawler.yml.example
@@ -59,7 +59,7 @@
 #
 ## Whether or not to include the full HTML in the crawl result Enabling full HTML extraction can
 ##   dramatically increase the index size if the site being crawled is large. Defaults to false.
-#extract_full_html: false
+#full_html_extraction_enabled: false
 #
 ## Scheduling using cron expressions
 #schedule:

--- a/config/crawler.yml.example
+++ b/config/crawler.yml.example
@@ -54,6 +54,13 @@
 ## The maximum depth that Crawler will follow links to.
 #max_crawl_depth: 2
 #
+## Whether or not the crawler should purge outdated documents after completing a crawl. Defaults to true
+#purge_crawl_enabled: true
+#
+## Whether or not to include the full HTML in the crawl result Enabling full HTML extraction can
+##   dramatically increase the index size if the site being crawled is large. Defaults to false.
+#extract_full_html: false
+#
 ## Scheduling using cron expressions
 #schedule:
 #  pattern: "0 12 * * *"     # every day at noon

--- a/lib/crawler/api/config.rb
+++ b/lib/crawler/api/config.rb
@@ -55,7 +55,7 @@ module Crawler
         :user_agent,           # The User-Agent used for requests made from the crawler.
         :stats_dump_interval,  # How often should we output stats in the logs during a crawl
         :purge_crawl_enabled,  # Whether or not to purge ES docs after a crawl, only possible for elasticsearch sinks
-        :extract_full_html,    # Whether or not to include the full HTML in the crawl result JSON
+        :full_html_extraction_enabled, # Whether or not to include the full HTML in the crawl result JSON
 
         # Elasticsearch settings
         :elasticsearch, # Elasticsearch connection settings
@@ -182,7 +182,7 @@ module Crawler
         extraction_rules: {},
         crawl_rules: {},
         purge_crawl_enabled: true,
-        extract_full_html: false
+        full_html_extraction_enabled: false
       }.freeze
 
       # Settings we are not allowed to log due to their sensitive nature

--- a/lib/crawler/api/config.rb
+++ b/lib/crawler/api/config.rb
@@ -54,7 +54,8 @@ module Crawler
         :results_collection,   # An Enumerable collection for storing mock crawl results
         :user_agent,           # The User-Agent used for requests made from the crawler.
         :stats_dump_interval,  # How often should we output stats in the logs during a crawl
-        :purge_crawl_enabled, # Whether or not to purge ES docs after a crawl, only possible for elasticsearch sinks
+        :purge_crawl_enabled,  # Whether or not to purge ES docs after a crawl, only possible for elasticsearch sinks
+        :extract_full_html,    # Whether or not to include the full HTML in the crawl result JSON
 
         # Elasticsearch settings
         :elasticsearch, # Elasticsearch connection settings
@@ -180,7 +181,8 @@ module Crawler
 
         extraction_rules: {},
         crawl_rules: {},
-        purge_crawl_enabled: true
+        purge_crawl_enabled: true,
+        extract_full_html: false
       }.freeze
 
       # Settings we are not allowed to log due to their sensitive nature

--- a/lib/crawler/document_mapper.rb
+++ b/lib/crawler/document_mapper.rb
@@ -64,7 +64,8 @@ module Crawler
         meta_keywords: crawl_result.meta_keywords(limit: config.max_keywords_size),
         meta_description: crawl_result.meta_description(limit: config.max_description_size),
         links: crawl_result.links(limit: config.max_indexed_links_count),
-        headings: crawl_result.headings(limit: config.max_headings_count)
+        headings: crawl_result.headings(limit: config.max_headings_count),
+        full_html: crawl_result.full_html(enabled: config.extract_full_html)
       )
     end
 

--- a/lib/crawler/document_mapper.rb
+++ b/lib/crawler/document_mapper.rb
@@ -57,7 +57,7 @@ module Crawler
       }
     end
 
-    def html_fields(crawl_result)
+    def html_fields(crawl_result) # rubocop:disable Metrics/AbcSize
       remove_empty_values(
         title: crawl_result.document_title(limit: config.max_title_size),
         body: crawl_result.document_body(limit: config.max_body_size),

--- a/lib/crawler/document_mapper.rb
+++ b/lib/crawler/document_mapper.rb
@@ -65,7 +65,7 @@ module Crawler
         meta_description: crawl_result.meta_description(limit: config.max_description_size),
         links: crawl_result.links(limit: config.max_indexed_links_count),
         headings: crawl_result.headings(limit: config.max_headings_count),
-        full_html: crawl_result.full_html(enabled: config.extract_full_html)
+        full_html: crawl_result.full_html(enabled: config.full_html_extraction_enabled)
       )
     end
 

--- a/spec/lib/crawler/document_mapper_spec.rb
+++ b/spec/lib/crawler/document_mapper_spec.rb
@@ -131,6 +131,26 @@ RSpec.describe(Crawler::DocumentMapper) do
           expect(result).to eq(expected_result_limited)
         end
       end
+
+      context "when full HTML extraction is enabled" do
+        let(:config_params) do
+          {
+            domains: [{ url: url.to_s}],
+            extract_full_html: true
+          }
+        end
+        let(:expected_result_extracted) do
+          expected_result.merge(
+            full_html: Nokogiri::HTML(content).inner_html
+          )
+        end
+
+        it 'includes the full HTML in the result' do
+          result = subject.create_doc(crawl_result)
+
+          expect(result).to eq(expected_result_extracted)
+        end
+      end
     end
 
     context 'when crawl result is a binary file' do

--- a/spec/lib/crawler/document_mapper_spec.rb
+++ b/spec/lib/crawler/document_mapper_spec.rb
@@ -132,10 +132,10 @@ RSpec.describe(Crawler::DocumentMapper) do
         end
       end
 
-      context "when full HTML extraction is enabled" do
+      context 'when full HTML extraction is enabled' do
         let(:config_params) do
           {
-            domains: [{ url: url.to_s}],
+            domains: [{ url: url.to_s }],
             full_html_extraction_enabled: true
           }
         end

--- a/spec/lib/crawler/document_mapper_spec.rb
+++ b/spec/lib/crawler/document_mapper_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe(Crawler::DocumentMapper) do
         let(:config_params) do
           {
             domains: [{ url: url.to_s}],
-            extract_full_html: true
+            full_html_extraction_enabled: true
           }
         end
         let(:expected_result_extracted) do


### PR DESCRIPTION
### Closes https://github.com/elastic/crawler/issues/198

Enable full HTML extraction through a config option.
The logic for this was already present in Crawler code, we were just missing two pieces: a configuration option, and to include the full HTML in the JSON to be ingested to ES.

#### Changes

- Add configuration `full_html_extraction_enabled` which defaults to `false`
- If enabled, include the full HTML in the crawl result doc under field `full_html`
- If disabled, don't include the field `full_html` at all
- (Bonus) add `purge_crawl_enabled` to example YAML file as it was missing
