### PR TITLE
[0.2] Add ingest pipeline for 9.x (#203)

### DIFF
--- a/spec/lib/crawler/api/crawl_spec.rb
+++ b/spec/lib/crawler/api/crawl_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe(Crawler::API::Crawl) do
 
   let(:es_client) { double }
   let(:es_client_indices) { double(:es_client_indices, exists: double) }
+  let(:build_info) { { version: { number: '8.99.0', build_flavor: 'default' } }.deep_stringify_keys }
 
   subject do
     described_class.new(crawl_config).tap do |crawl|
@@ -49,7 +50,7 @@ RSpec.describe(Crawler::API::Crawl) do
 
     allow(ES::Client).to receive(:new).and_return(es_client)
     allow(es_client).to receive(:indices).and_return(es_client_indices)
-    allow(es_client).to receive(:info).and_return(true)
+    allow(es_client).to receive(:info).and_return(build_info)
   end
 
   #-------------------------------------------------------------------------------------------------

--- a/spec/lib/crawler/coordinator_spec.rb
+++ b/spec/lib/crawler/coordinator_spec.rb
@@ -80,11 +80,12 @@ RSpec.describe(Crawler::Coordinator) do
         _source: { url: 'https://example.com/outdated' }
       }.stringify_keys
     end
+    let(:build_info) { { version: { number: '8.99.0', build_flavor: 'default' } }.deep_stringify_keys }
 
     before do
       allow(ES::Client).to receive(:new).and_return(es_client)
       allow(es_client).to receive(:bulk)
-      allow(es_client).to receive(:info).and_return(true)
+      allow(es_client).to receive(:info).and_return(build_info)
       allow(es_client).to receive(:delete_by_query).and_return({ deleted: 1 }.stringify_keys)
       allow(es_client)
         .to receive(:paginated_search).and_return([search_result])

--- a/spec/lib/crawler/output_sink_spec.rb
+++ b/spec/lib/crawler/output_sink_spec.rb
@@ -11,11 +11,12 @@ RSpec.describe(Crawler::OutputSink) do
 
   let(:es_client) { double }
   let(:es_client_indices) { double(:es_client_indices, exists: double) }
+  let(:build_info) { { version: { number: '8.99.0', build_flavor: 'default' } }.deep_stringify_keys }
 
   before(:each) do
     allow(ES::Client).to receive(:new).and_return(es_client)
     allow(es_client).to receive(:indices).and_return(es_client_indices)
-    allow(es_client).to receive(:info).and_return(true)
+    allow(es_client).to receive(:info).and_return(build_info)
   end
 
   context '.create' do


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `0.2`:
 - [Add ingest pipeline for 9.x (#203)](https://github.com/elastic/crawler/pull/203)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)