### PR TITLE
Add libcurl to installed libs

### DIFF
--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -6,7 +6,7 @@ USER root
 # we need curl and make below, but then we remove them later
 # TODO maybe we can do multi-stage to reduce layers in the final image
 
-RUN apk update && apk add --no-cache curl make
+RUN apk update && apk add --no-cache curl make curl-dev
 
 # ------------------------------------------------------------------------------
 # jruby install steps below have been adapted from:


### PR DESCRIPTION
Resolve CI failure likely caused by recent release of curl:

```
Step 6/22 : RUN mkdir /opt/jruby   && curl -fSL https://repo1.maven.org/maven2/org/jruby/jruby-dist/${JRUBY_VERSION}/jruby-dist-${JRUBY_VERSION}-bin.tar.gz -o /tmp/jruby.tar.gz   && echo "$JRUBY_SHA256 /tmp/jruby.tar.gz" | sha256sum -c -   && tar -zx --strip-components=1 -f /tmp/jruby.tar.gz -C /opt/jruby   && rm /tmp/jruby.tar.gz
 ---> Running in 9bf1d7e98f6c
curl: symbol lookup error: curl: undefined symbol: curl_easy_ssls_export
The command '/bin/sh -c mkdir /opt/jruby   && curl -fSL https://repo1.maven.org/maven2/org/jruby/jruby-dist/${JRUBY_VERSION}/jruby-dist-${JRUBY_VERSION}-bin.tar.gz -o /tmp/jruby.tar.gz   && echo "$JRUBY_SHA256 /tmp/jruby.tar.gz" | sha256sum -c -   && tar -zx --strip-components=1 -f /tmp/jruby.tar.gz -C /opt/jruby   && rm /tmp/jruby.tar.gz' returned a non-zero code: 127
```