### PR TITLE
Update default docker-compose version

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   crawler:
-    image: docker.elastic.co/integrations/crawler:${CRAWLER_VERSION:-0.2.0}
+    image: docker.elastic.co/integrations/crawler:${CRAWLER_VERSION:-0.2.1}
     container_name: crawler
     volumes:
       - ./config:/app/config


### PR DESCRIPTION
0.2.1 was just released and is our latest version, so bump the default version in docker-compose so new users can use it.