### PR TITLE
[0.2] Add&#x60;:latest&#x60; tag option to build jobs (#214)

### DIFF
--- a/.buildkite/publish/publish-common.sh
+++ b/.buildkite/publish/publish-common.sh
@@ -16,6 +16,14 @@ PROJECT_ROOT=$(realpath "$(dirname "$BUILDKITE_DIR")")
 VERSION_PATH="$PROJECT_ROOT/product_version"
 VERSION=$(cat "$VERSION_PATH")
 IS_SNAPSHOT=$(buildkite-agent meta-data get is_snapshot)
+IS_LATEST=$(buildkite-agent meta-data get is_latest)
+
+if [[ "${IS_SNAPSHOT:-}" == "false" && "${IS_LATEST:-}" == "true" ]]; then
+  # don't apply LATEST tag to SNAPSHOT builds
+  export APPLY_LATEST_TAG="true"
+else
+  export APPLY_LATEST_TAG="false"
+fi
 
 export BUILDKITE_DIR
 export PROJECT_ROOT

--- a/.buildkite/release-pipeline.yml
+++ b/.buildkite/release-pipeline.yml
@@ -4,12 +4,19 @@
 steps:
   - input: "Build information"
     fields:
-      - select: "Build as SNAPSHOT"
+      - select: "Build as a SNAPSHOT?"
         key: "is_snapshot"
         options:
-          - label: "True"
+          - label: "Yes"
             value: "true"
-          - label: "False"
+          - label: "No"
+            value: "false"
+      - select: "Apply :latest tag?"
+        key: "is_latest"
+        options:
+          - label: "Yes"
+            value: "true"
+          - label: "No"
             value: "false"
   - wait: ~
   # ----

--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@ Open Crawler enables users to easily ingest web content into Elasticsearch.
 Beta features are subject to change and are not covered by the support SLA of generally available (GA) features.
 Elastic plans to promote this feature to GA in a future release.
 
-_Open Crawler `v0.2` is confirmed to be compatible with Elasticsearch `v8.13.0` and above._
+### ES Version Compatibility
+
+| Elasticsearch | Open Crawler       |
+|---------------|--------------------|
+| `8.x`         | `v0.2.x`           |
+| `9.x`         | `v0.2.1` and above |
 
 ### User workflow
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `0.2`:
 - [Add&#x60;:latest&#x60; tag option to build jobs (#214)](https://github.com/elastic/crawler/pull/214)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)