### PR TITLE
Response code 304 should not be treated as a redirect

### DIFF
--- a/lib/crawler/http_utils/response.rb
+++ b/lib/crawler/http_utils/response.rb
@@ -102,7 +102,8 @@ module Crawler
       end
 
       def redirect?
-        code >= 300 && code <= 399
+        # We should ignore code 304s as they do not contain a location field in the header
+        code >= 300 && code <= 399 && code != 304
       end
 
       def error?


### PR DESCRIPTION
### Closes https://github.com/elastic/search-team/issues/9216

Response code 304 should not be treated as a redirect as it does contain a location field in header.

### Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] This PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `crawler.yml.example` and `elasticsearch.yml.example`)
- [x] This PR has a meaningful title
- [x] This PR links to all relevant GitHub issues that it fixes or partially addresses
    - If there is no GitHub issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v0.1.0`)