### PR TITLE
Update API key permissions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ If using an API key, ensure that the API key has read and write permissions to a
         "indices": [
           {
             "names": ["my-crawler-index-name"],
-            "privileges": ["all"]
+            "privileges": ["monitor"]
           }
         ]
       }


### PR DESCRIPTION
Closes https://github.com/elastic/crawler/issues/224

`all` is not required to run a crawl, `monitor` is sufficient.
