### PR TITLE
Run renovate only on weekends

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>elastic/renovate-config:only-chainguard"
+  ],
+  "schedule": [
+    "* * * * 0,6"
   ]
 }


### PR DESCRIPTION
See https://elastic.slack.com/archives/C01795T48LQ/p1743165270846379:

Renovate sending updates every day makes the routine harder to handle. I feel it's great to batch it during weekends, and then resolve all on Monday/Tuesday.