### PR TITLE
chore: install latest curl

### DIFF
--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -5,7 +5,7 @@ USER root
 # ------------------------------------------------------------------------------
 # we need curl and make below, but then we remove them later
 # TODO maybe we can do multi-stage to reduce layers in the final image
-RUN apk update && apk add --no-cache curl=8.11.1-r0 make
+RUN apk update && apk add --no-cache curl make
 
 # ------------------------------------------------------------------------------
 # jruby install steps below have been adapted from:


### PR DESCRIPTION
Installing older curl seems to be linked to vulnerability as reported by SNYK, trying to install newer version of curl

Relates to: [9092](https://github.com/elastic/search-team/issues/9092)