### PR TITLE
Fix curl dependency issue

### DIFF
--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -5,7 +5,7 @@ USER root
 # ------------------------------------------------------------------------------
 # we need curl and make below, but then we remove them later
 # TODO maybe we can do multi-stage to reduce layers in the final image
-RUN apk update && apk add --no-cache curl make
+RUN apk update && apk add --no-cache libcurl-openssl4=~8.12.1 curl=~8.12.1 make
 
 # ------------------------------------------------------------------------------
 # jruby install steps below have been adapted from:


### PR DESCRIPTION
- Pin `libcurl-openssl4` to `8.12.1` and ensure it is added before `curl`
- Pin `curl` to `8.12.1`

curl 8.12.x has a dependency on libcurl, but due to a version mismatch in the wolfi image, the correct libcurl version is not used by curl. This results in errors when using curl:

```
$ curl --version
curl: symbol lookup error: curl: undefined symbol: curl_easy_ssls_export
```

See this discussion in the wofli repo: https://github.com/orgs/wolfi-dev/discussions/41391
