### PR TITLE
Add log volume mount to docker-compose.yml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,7 @@ services:
     container_name: crawler
     volumes:
       - ./config:/app/config
+      - ./logs:/app/logs
     networks:
       - elastic
     stdin_open: true   # Equivalent to -i


### PR DESCRIPTION
### Part of https://github.com/elastic/search-team/issues/7275

This PR adds a `/logs` volume mount (similar to the `/config` mount) to the `docker-compose.yml` so that log files are accessible outside of the Docker container.

### Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] This PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `crawler.yml.example` and `elasticsearch.yml.example`)
- [x] This PR has a meaningful title
- [ ] This PR links to all relevant GitHub issues that it fixes or partially addresses
    - If there is no GitHub issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v0.1.0`)
- [x] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference