### PR TITLE
[0.2] Fix Docker permissions issues + Adding optional log volume mount (#248)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,17 @@ RUN apt-get update && \
 # used for skipping jenv/rbenv setup
 ENV IS_DOCKER=1
 
-COPY . /app
-WORKDIR /app
+# Set up crawlergroup and crawleruser
+RUN groupadd -g 451 crawlergroup && \
+    useradd -m -u 451 -g crawlergroup crawleruser
+
+# Copy and set up Crawler as crawleruser
+USER crawleruser
+COPY --chown=crawleruser:crawlergroup --chmod=775 . /home/app
+WORKDIR /home/app
 RUN make clean install
 
 # Clean up build dependencies
-RUN rm -r /root/.m2
+RUN rm -r /home/crawleruser/.m2
 
 ENTRYPOINT [ "/bin/bash" ]

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -46,9 +46,10 @@ RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
 # the container image, since we are adding lots of stuff here that we do not need
 # and may not want (do we need vendor/ after the make install below, for instance?),
 # contributing to increased image size; for now at least we can remove `.git` (below)
-COPY . /app
 
-WORKDIR /app
+# java is the base image's default us
+COPY --chown=java:java --chmod=775 . /home/app
+WORKDIR /home/app
 
 # skip jenv/rbenv setup
 ENV IS_DOCKER=1
@@ -63,7 +64,7 @@ RUN rm -r /root/.m2
 
 RUN apk del curl make git \
     && apk --purge del apk-tools \
-    && rm -rf /app/.git
+    && rm -rf /home/app/.git
 
 # switch back to the base image's default user when running the application
 USER java

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,18 @@
+services:
+  crawler:
+    image: docker.elastic.co/integrations/crawler:${CRAWLER_VERSION:-latest}
+    container_name: crawler
+    volumes:
+      - ./config:/home/app/config
+#      - ./logs:/home/app/logs # Enable this to access log files outside the Docker container
+    networks:
+      - elastic
+    stdin_open: true   # Equivalent to -i
+    tty: true          # Required for interactive mode
+    # Uncomment enviroment variable if running on MacOS M4 and experiencing Java Runtime errors
+    # environment:
+    #   - "_JAVA_OPTIONS=-XX:UseSVE=0"
+
+networks:
+  elastic:
+    driver: bridge

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -18,9 +18,6 @@ If you are running a dockerized version of Crawler, you can run CLI commands in 
     ```bash
     # exec into container
     $ docker exec -it crawler bash
-   
-    # move to crawler directory
-    $ cd crawler
     
     # execute commands
     $ bin/crawler version

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -37,7 +37,7 @@ If you are running Crawler in docker, you will need to copy any configuration fi
 This will need to be done every time a change is made to these files, unless you are editing the file directly inside the Docker container.
 
 ```bash
-$ docker cp /path/to/my-crawler.yml crawler:app/config/my-crawler.yml
+docker cp /path/to/my-crawler.yml crawler:/home/app/config/my-crawler.yml
 ```
 
 ## Example usage


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `0.2`:
 - [Fix Docker permissions issues + Adding optional log volume mount (#248)](https://github.com/elastic/crawler/pull/248)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)