### PR TITLE
Add Meta tag and data attribute extraction

### DIFF
--- a/lib/crawler/data/crawl_result/html.rb
+++ b/lib/crawler/data/crawl_result/html.rb
@@ -124,6 +124,38 @@ module Crawler
           Crawler::ContentEngine::Utils.limit_bytesize(description, limit)
         end
 
+        def meta_tag_elastic(limit: 1024)
+          meta_elastic_class = 'elastic'
+          meta_tag_selector = "meta.#{meta_elastic_class}"
+
+          # filter by the meta_tag_selector first to only get meta tags with class='elastic'
+          extractions = {}
+          parsed_content.css(meta_tag_selector).css('meta[name][content]').each do |meta|
+            # truncate the content field of each tag we extract
+            truncated_content = Crawler::ContentEngine::Utils.limit_bytesize(
+              meta['content'],
+              limit
+            )
+            extractions[meta['name']] = truncated_content
+          end
+          extractions
+        end
+
+        def meta_tag_data(limit: 1024)
+          data_elastic_name = 'data-elastic-name'
+          body_embedded_tag_selector = "[#{data_elastic_name}]"
+
+          extractions = {}
+          parsed_content.css('body').css(body_embedded_tag_selector).each do |data|
+            truncated_content = Crawler::ContentEngine::Utils.limit_bytesize(
+              data.text.to_s.squish,
+              limit
+            )
+            extractions[data[data_elastic_name]] = truncated_content
+          end
+          extractions
+        end
+
         #---------------------------------------------------------------------------------------------
         # Returns the title of the document, cleaned up for indexing
         def document_title(limit: 1000)

--- a/lib/crawler/document_mapper.rb
+++ b/lib/crawler/document_mapper.rb
@@ -63,6 +63,7 @@ module Crawler
         body: crawl_result.document_body(limit: config.max_body_size),
         meta_keywords: crawl_result.meta_keywords(limit: config.max_keywords_size),
         meta_description: crawl_result.meta_description(limit: config.max_description_size),
+        meta_content: crawl_result.meta_tag_elastic,
         links: crawl_result.links(limit: config.max_indexed_links_count),
         headings: crawl_result.headings(limit: config.max_headings_count),
         full_html: crawl_result.full_html(enabled: config.full_html_extraction_enabled)

--- a/spec/lib/crawler/data/crawl_result/html_spec.rb
+++ b/spec/lib/crawler/data/crawl_result/html_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe(Crawler::Data::CrawlResult::HTML) do
         <link rel="canonical" href="https://example.com/canonical" />
         <meta name="keywords" content="keywords, stuffing, SEO" />
         <meta name="description" content="The best site in the universe!" />
+        <meta class="elastic" name="Number" content="0451">
+        <meta class="elastic" name="String" content="elastician">
       </head>
       <body>
         <h1>Page header</h1>
@@ -35,6 +37,9 @@ RSpec.describe(Crawler::Data::CrawlResult::HTML) do
 
         <!-- should remove this whole tag -->
         <script>alert("hello from Javascript")</script>
+      #{'  '}
+        <div data-elastic-name="in-body-tag">Elasticize</div>
+        <div data-elastic-name="second-in-body-tag">ELK</div>
 
         <!-- should remove this whole tag -->
         <svg height="130" width="500">
@@ -356,7 +361,6 @@ RSpec.describe(Crawler::Data::CrawlResult::HTML) do
     end
   end
 
-  #-------------------------------------------------------------------------------------------------
   describe '#meta_description' do
     it 'should return keywords' do
       expect(crawl_result.meta_description).to eq('The best site in the universe!')
@@ -364,6 +368,26 @@ RSpec.describe(Crawler::Data::CrawlResult::HTML) do
 
     it 'should truncate the value to a given length' do
       expect(crawl_result.meta_description(limit: 10).bytesize).to eq(10)
+    end
+  end
+
+  describe '#meta_tag_elastic' do
+    it 'should return all elastic class meta tags' do
+      expect(crawl_result.meta_tag_elastic).to eq({ 'Number' => '0451', 'String' => 'elastician' })
+    end
+
+    it 'should truncate values to a given length' do
+      expect(crawl_result.meta_tag_elastic(limit: 10)['String'].bytesize).to eq(10)
+    end
+  end
+
+  describe '#meta_tag_data' do
+    it 'should return all body data tags' do
+      expect(crawl_result.meta_tag_data).to eq({ 'in-body-tag' => 'Elasticize', 'second-in-body-tag' => 'ELK' })
+    end
+
+    it 'should truncate values to a given length' do
+      expect(crawl_result.meta_tag_data(limit: 10)['in-body-tag'].bytesize).to eq(10)
     end
   end
 


### PR DESCRIPTION
### Closes https://github.com/elastic/search-team/issues/7273

This PR adds meta tag and data attribute extraction functionality to Open Crawler. This was a feature in [previous](https://www.elastic.co/guide/en/enterprise-search/current/crawler-content.html#crawler-content-meta-tags-content-extraction) versions of Crawler and is now being added here.

### Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] This PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `crawler.yml.example` and `elasticsearch.yml.example`)
- [x] This PR has a meaningful title
- [x] This PR links to all relevant GitHub issues that it fixes or partially addresses
    - If there is no GitHub issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v0.1.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference