### PR TITLE
Ensure run_urltest_crawl!() method sets the @crawl_stage instance variable

### DIFF
--- a/lib/crawler/coordinator.rb
+++ b/lib/crawler/coordinator.rb
@@ -117,6 +117,7 @@ module Crawler
     end
 
     def run_urltest_crawl!(endpoint)
+      @crawl_stage = CRAWL_STAGE_PRIMARY
       @url_test = true
       url_obj = Crawler::Data::URL.parse(endpoint)
       add_url_to_backlog(


### PR DESCRIPTION
### Closes https://github.com/elastic/crawler/issues/274

Quick fix to ensure the logs accurately reflect the success or failure of a `urltest` crawl

The problem was caused by Crawler not knowing what 'stage' the `urltest` crawl is.

The `@crawl_stage` instance variable sets a key, either `CRAWL_STAGE_PRIMARY` or `CRAWL_STAGE_PURGE`, that is then used to update a value in `crawl_results` to either 'success' or 'failure'. This `crawl_results` gets sent back to the calling method in `lib/api/crawl.rb`, which ANDs the results of both CRAWL_STAGE_PRIMARY and CRAWL_STAGE_PURGE together and marks the entire crawl as either a success or failure.

In the case of `urltest`, the method never explicitly set the crawl stage to `CRAWL_STAGE_PRIMARY`, so `crawl_results` wasn't getting updated properly, thus resulting in a processed outcome of `failure`

### Checklists

#### Pre-Review Checklist
- [x] This PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `crawler.yml.example` and `elasticsearch.yml.example`)
- [x] This PR has a meaningful title
- [x] This PR links to all relevant GitHub issues that it fixes or partially addresses
    - If there is no GitHub issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v0.1.0`)