### PR TITLE
[Synk] [CVE-2025-32415] Bump Nokogiri to 1.18.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ group :default do
   gem 'bson', '~> 4.15.0', platform: :jruby
   gem 'bigdecimal', '~> 3.1.7', platform: :jruby
   gem 'json', '~> 2.7.2', platform: :jruby
-  gem 'nokogiri', '~> 1.18.6', platform: :jruby
+  gem 'nokogiri', '~> 1.18.8', platform: :jruby
   gem 'racc', '~> 1.7.3', platform: :jruby
   gem 'strscan', '~> 3.1.0', platform: :jruby
   gem 'thread_safe', '~> 0.3.6', platform: :jruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,7 @@ GEM
     method_source (1.1.0)
     minitest (5.22.3)
     multi_json (1.15.0)
-    nokogiri (1.18.6-java)
+    nokogiri (1.18.8-java)
       racc (~> 1.4)
     parallel (1.24.0)
     parser (3.3.1.0)
@@ -170,7 +170,7 @@ DEPENDENCIES
   ipaddr (~> 1.2.4)
   json (~> 2.7.2)
   json-schema (~> 4.3.0)
-  nokogiri (~> 1.18.6)
+  nokogiri (~> 1.18.8)
   pry (~> 0.14.2)
   pry-nav
   pry-remote


### PR DESCRIPTION
### Closes https://github.com/elastic/search-team/issues/9867

This PR bumps `nokogiri` to 1.18.8, as 1.18.6 is vulnerable to a buffer under-read.
I don't think we are vulnerable, but this is a minor version bump and is trivial to do.

### Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] This PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `crawler.yml.example` and `elasticsearch.yml.example`)
- [x] This PR has a meaningful title
- [x] This PR links to all relevant GitHub issues that it fixes or partially addresses
    - If there is no GitHub issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v0.1.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] Ran `make notice` if any dependencies have been added