### PR TITLE
[GA] Pretty-print post-completion summary counters

### DIFF
--- a/lib/crawler/api/crawl.rb
+++ b/lib/crawler/api/crawl.rb
@@ -110,7 +110,7 @@ module Crawler
           crawl_queue.delete
           seen_urls.clear
           print_final_crawl_status
-          print_crawl_ingestion_results(ingestion_stats) if config.output_sink == 'elasticsearch'
+          print_crawl_ingestion_results(ingestion_stats) if config.output_sink.to_s == 'elasticsearch'
         end
       end
 
@@ -206,13 +206,23 @@ module Crawler
       end
 
       def print_crawl_ingestion_results(ingestion_stats)
+        return if ingestion_stats.nil?
+
+        completed_stats = ingestion_stats.fetch(:completed, {})
+        failed_stats = ingestion_stats.fetch(:failed, {})
+
         puts "\n---- Elasticsearch Ingestion Stats ----"
-        puts '- Completed'
-        puts "  - Documents upserted: #{ingestion_stats[:completed][:docs_count]}"
-        puts "  - Volume (bytes): #{ingestion_stats[:completed][:docs_volume]}"
+        unless completed_stats.empty?
+          puts '- Completed'
+          puts "  - Documents upserted: #{completed_stats.fetch(:docs_count, 0)}"
+          puts "  - Volume (bytes): #{completed_stats.fetch(:docs_volume, 0)}"
+        end
+
+        return if failed_stats.empty?
+
         puts '- Failed'
-        puts "  - Number of documents that failed to index: #{ingestion_stats[:failed][:docs_count]}"
-        puts "  - Volume (bytes): #{ingestion_stats[:failed][:docs_volume]}"
+        puts "  - Number of documents that failed to index: #{failed_stats.fetch(:docs_count, 0)}"
+        puts "  - Volume (bytes): #{failed_stats.fetch(:docs_volume, 0)}"
       end
 
       def print_final_crawl_status # rubocop:disable Metrics/AbcSize

--- a/lib/crawler/coordinator.rb
+++ b/lib/crawler/coordinator.rb
@@ -75,11 +75,13 @@ module Crawler
 
       # Close the sink to make sure all the in-flight content has been safely stored/indexed/etc
       system_logger.info('Closing the output sink before finishing the crawl...')
-      sink.close
+      ingestion_stats = sink.close
 
       # Final dump of crawl stats
       events.log_crawl_status(crawl, force: true)
       system_logger.info('Crawl shutdown complete')
+
+      ingestion_stats # return ingestion stats to be printed later
     end
 
     def run_primary_crawl!

--- a/lib/crawler/output_sink/elasticsearch.rb
+++ b/lib/crawler/output_sink/elasticsearch.rb
@@ -152,7 +152,13 @@ module Crawler
           Failed to index #{@failed[:docs_count]} docs with a volume of #{@failed[:docs_volume]} bytes.
           Deleted #{@deleted} outdated docs from the index.
         LOG
-        system_logger.info(msg)
+        msg_improved = <<~LOG
+          All indexing operations completed
+          - Successfully upserted #{@completed[:docs_count]} documents (#{@completed[:docs_volume]} bytes)
+          - Failed to index #{@failed[:docs_count]} documents (#{@failed[:docs_volume]} bytes)
+          - Deleted #{@deleted} documents from index #{config.output_index}.
+        LOG
+        system_logger.info(msg_improved)
       end
 
       def flush # rubocop:disable Metrics/AbcSize, Metrics/MethodLength

--- a/lib/crawler/output_sink/elasticsearch.rb
+++ b/lib/crawler/output_sink/elasticsearch.rb
@@ -152,13 +152,8 @@ module Crawler
           Failed to index #{@failed[:docs_count]} docs with a volume of #{@failed[:docs_volume]} bytes.
           Deleted #{@deleted} outdated docs from the index.
         LOG
-        msg_improved = <<~LOG
-          All indexing operations completed
-          - Successfully upserted #{@completed[:docs_count]} documents (#{@completed[:docs_volume]} bytes)
-          - Failed to index #{@failed[:docs_count]} documents (#{@failed[:docs_volume]} bytes)
-          - Deleted #{@deleted} documents from index #{config.output_index}.
-        LOG
-        system_logger.info(msg_improved)
+        system_logger.info(msg)
+        ingestion_stats # return ingestion stats to run_crawl! method
       end
 
       def flush # rubocop:disable Metrics/AbcSize, Metrics/MethodLength

--- a/spec/lib/crawler/api/crawl_spec.rb
+++ b/spec/lib/crawler/api/crawl_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe(Crawler::API::Crawl) do
 
   it 'has a config' do
     expect(subject.config.seed_urls.map(&:to_s).to_a).to eq(["#{url}/"])
-    expect(subject.config.output_sink).to eq(:elasticsearch)
+    expect(subject.config.output_sink.to_s).to eq('elasticsearch')
   end
 
   it 'has a output sink' do
@@ -71,6 +71,17 @@ RSpec.describe(Crawler::API::Crawl) do
   end
 
   context 'after a successful crawl' do
+    it 'should print final crawl stats' do
+      expect(subject).to receive(:print_final_crawl_status)
+      subject.start!
+    end
+
+    it 'should print Elasticsearch ingestion stats' do
+      expect(subject).to receive(:print_crawl_ingestion_results)
+
+      subject.start!
+    end
+
     it 'should release URL queue resources' do
       expect(subject.crawl_queue).to receive(:delete)
       subject.start!

--- a/spec/lib/crawler/api/crawl_spec.rb
+++ b/spec/lib/crawler/api/crawl_spec.rb
@@ -42,14 +42,13 @@ RSpec.describe(Crawler::API::Crawl) do
     {
       completed: {
         docs_count: 9,
-        docs_volume: 14597
+        docs_volume: 14_597
       },
       failed: {
         docs_count: 0,
         docs_volume: 0
       }
     }
-
   end
 
   subject do


### PR DESCRIPTION
### Closes https://github.com/elastic/crawler/issues/184

The aim of this PR is to print, in human-readable form, end-of-crawl stats as well as Elasticsearch-specific stats _if Elasticsearch is the designated output sink_.

The info printed is already captured by existing logging, so this data is purely for the sake of the user to have a nice, formatted output of stats.

Example output:
```
---- Crawl Stats ----
- Pages visited: 11
- URLs allowed: 10
- URLs denied
  - Already seen: 91
  - Domain filter: 9
- Crawl duration (seconds): 5
- Crawling time (seconds): 0.528
- Average response time (seconds): 0.048

---- Elasticsearch Ingestion Stats ----
- Completed
  - Documents upserted: 9
  - Volume (bytes): 14597
- Failed
  - Number of documents that failed to index: 0
  - Volume (bytes): 0

```

### Checklists
#### Pre-Review Checklist
- [x] This PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `crawler.yml.example` and `elasticsearch.yml.example`)
- [x] This PR has a meaningful title
- [x] This PR links to all relevant GitHub issues that it fixes or partially addresses
    - If there is no GitHub issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v0.1.0`)