### PR TITLE
Remove line break comments

### DIFF
--- a/lib/crawler/api/crawl.rb
+++ b/lib/crawler/api/crawl.rb
@@ -47,7 +47,6 @@ module Crawler
       delegate :system_logger, :events, :stats, to: :config
       delegate :rule_engine, to: :sink
 
-      #---------------------------------------------------------------------------------------------
       def shutdown_started?
         @shutdown_started.true?
       end
@@ -65,7 +64,6 @@ module Crawler
         @shutdown_started.make_true
       end
 
-      #---------------------------------------------------------------------------------------------
       # Waits for a specified number of seconds, stopping earlier if we are in a shutdown mode
       def interruptible_sleep(period)
         start_time = Time.now
@@ -77,12 +75,10 @@ module Crawler
         end
       end
 
-      #---------------------------------------------------------------------------------------------
       def coordinator
         @coordinator ||= Crawler::Coordinator.new(self)
       end
 
-      #---------------------------------------------------------------------------------------------
       # Starts a new crawl described by the given config. The job is started immediately.
       def start! # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
         events.crawl_start(
@@ -136,7 +132,6 @@ module Crawler
         seen_urls.clear
       end
 
-      #---------------------------------------------------------------------------------------------
       # Returns a hash with crawl-specific status information
       # Note: This is used by the `EventGenerator` class for crawl-status events and by the Crawler Status API.
       #       Please update OpenAPI specs if you add any new fields here.

--- a/lib/crawler/coordinator.rb
+++ b/lib/crawler/coordinator.rb
@@ -55,7 +55,6 @@ module Crawler
       @started_at = Time.now
     end
 
-    #-----------------------------------------------------------------------------------------------
     # Returns crawl duration in seconds or +nil+ if crawl has not been started yet
     def crawl_duration
       started_at ? Time.now - started_at : nil
@@ -66,7 +65,6 @@ module Crawler
       task_executors.length
     end
 
-    #-----------------------------------------------------------------------------------------------
     def run_crawl!
       run_primary_crawl!
       run_purge_crawl! if purge_crawls_allowed?
@@ -147,7 +145,6 @@ module Crawler
       true
     end
 
-    #-----------------------------------------------------------------------------------------------
     # Communicates the progress on a given crawl task via the system log and Java thread names
     def crawl_task_progress(crawl_task, message)
       progress_message = "#{crawl_task.inspect}: #{message}"
@@ -155,7 +152,6 @@ module Crawler
       system_logger.debug("Crawl task progress: #{progress_message}")
     end
 
-    #-----------------------------------------------------------------------------------------------
     # Loads robots.txt for each configured domain and registers it
     def load_robots_txts
       config.domain_allowlist.each do |domain|
@@ -167,7 +163,6 @@ module Crawler
       end
     end
 
-    #-----------------------------------------------------------------------------------------------
     # Fetches robots.txt for a given domain and returns it as a crawl result
     def load_robots_txt(domain)
       crawl_task = Crawler::Data::CrawlTask.new(
@@ -197,7 +192,6 @@ module Crawler
       crawl_result
     end
 
-    #-----------------------------------------------------------------------------------------------
     # Seed the crawler with configured URLs
     def enqueue_seed_urls
       system_logger.debug("Seeding the crawl with #{config.seed_urls.size} URLs...")
@@ -209,7 +203,6 @@ module Crawler
       )
     end
 
-    #-----------------------------------------------------------------------------------------------
     # Seed the crawler with pre-configured sitemaps
     def enqueue_sitemaps
       if config.sitemap_urls.any?
@@ -257,19 +250,16 @@ module Crawler
       end
     end
 
-    #-----------------------------------------------------------------------------------------------
     def set_outcome(outcome, message)
       @crawl_results[@crawl_stage][:outcome] = outcome
       @crawl_results[@crawl_stage][:message] = message
     end
 
-    #-----------------------------------------------------------------------------------------------
     # Returns +true+ if there are any free executors available to run crawl tasks
     def executors_available?
       task_executors.length < task_executors.max_length
     end
 
-    #-----------------------------------------------------------------------------------------------
     # Checks if we should terminate the crawl loop and sets the outcome value accordingly
     def crawl_finished?
       return true if @crawl_results[@crawl_stage][:outcome]
@@ -325,7 +315,6 @@ module Crawler
       log_crawl_end_event
     end
 
-    #-----------------------------------------------------------------------------------------------
     # Performs a single iteration of the crawl loop
     def prepare_crawl_task
       return if shutdown_started?
@@ -348,7 +337,6 @@ module Crawler
       end
     end
 
-    #-----------------------------------------------------------------------------------------------
     def execute_crawl_task(crawl_task)
       # Fetch the page.
       crawl_result = execute_task(crawl_task)
@@ -361,7 +349,6 @@ module Crawler
       raise
     end
 
-    #-----------------------------------------------------------------------------------------------
     # Fetches a URL and logs info about the HTTP request/response.
     def execute_task(crawl_task, follow_redirects: false)
       crawl_task_progress(crawl_task, 'HTTP execution')
@@ -372,7 +359,6 @@ module Crawler
       end
     end
 
-    #-----------------------------------------------------------------------------------------------
     # Process a crawl_result:
     # - Extract canonical_url and add it to the backlog
     # - Extract links contained in the page and add them to the backlog
@@ -416,7 +402,6 @@ module Crawler
       events.url_extracted(**extracted_event)
     end
 
-    #-----------------------------------------------------------------------------------------------
     # Extracts links from a given crawl result and pushes them into the crawl queue for processing
     def extract_and_enqueue_links(crawl_task, crawl_result)
       return if crawl_result.error? || @crawl_stage == CRAWL_STAGE_PURGE
@@ -428,7 +413,6 @@ module Crawler
       extract_and_enqueue_sitemap_links(crawl_task, crawl_result) if crawl_result.sitemap?
     end
 
-    #-----------------------------------------------------------------------------------------------
     def enqueue_redirect_link(crawl_task, crawl_result)
       add_urls_to_backlog(
         urls: [crawl_result.location],
@@ -440,7 +424,6 @@ module Crawler
       )
     end
 
-    #-----------------------------------------------------------------------------------------------
     def extract_and_enqueue_html_links(crawl_task, crawl_result)
       canonical_link = crawl_result.canonical_link
       if canonical_link
@@ -476,7 +459,6 @@ module Crawler
       )
     end
 
-    #-----------------------------------------------------------------------------------------------
     def extract_and_enqueue_sitemap_links(crawl_task, crawl_result)
       result = crawl_result.extract_links
       limit_reached, error = result.values_at(:limit_reached, :error)
@@ -505,7 +487,6 @@ module Crawler
       end
     end
 
-    #-----------------------------------------------------------------------------------------------
     def extract_links(crawl_result, crawl_depth:)
       extracted_links = crawl_result.extract_links(limit: config.max_extracted_links_count)
       links, limit_reached = extracted_links.values_at(:links, :limit_reached)
@@ -533,7 +514,6 @@ module Crawler
       end
     end
 
-    #-----------------------------------------------------------------------------------------------
     # Outputs the results of a single URL processing to an output module configured for the crawl
     def output_crawl_result(crawl_result)
       retries = 0
@@ -567,7 +547,6 @@ module Crawler
       end
     end
 
-    #-----------------------------------------------------------------------------------------------
     # Adds a set of URLs to the backlog for processing (if they are OK to follow)
     def add_urls_to_backlog(urls:, type:, source_type:, crawl_depth:, source_url: nil, redirect_chain: []) # rubocop:disable Metrics/ParameterLists
       return unless urls.any?
@@ -618,7 +597,6 @@ module Crawler
       events.crawl_seed(added_urls_count, type: :content) if source_type == SEED_LIST
     end
 
-    #-----------------------------------------------------------------------------------------------
     # Adds a single url to the backlog for processing and logs an event associated with it
     # If the queue is full, drops the item on the floor and logs about it.
     def add_url_to_backlog(url:, type:, source_type:, crawl_depth:, source_url:, redirect_chain: []) # rubocop:disable Metrics/ParameterLists
@@ -653,7 +631,6 @@ module Crawler
       )
     end
 
-    #-----------------------------------------------------------------------------------------------
     # Receives a newly-discovered url, makes a decision on what to do with it and records it in the log
     # FIXME: Feels like we need a generic way of encoding URL decisions, probably in the rules engine
     def check_discovered_url(url:, type:, source_url:, crawl_depth:) # rubocop:disable Metrics/PerceivedComplexity

--- a/lib/crawler/data/crawl_result/base.rb
+++ b/lib/crawler/data/crawl_result/base.rb
@@ -35,7 +35,6 @@ module Crawler
         # Hide the constructor from the base class
         private_class_method :new
 
-        #---------------------------------------------------------------------------------------------
         def url_hash
           url.normalized_hash
         end
@@ -66,7 +65,6 @@ module Crawler
           to_s
         end
 
-        #---------------------------------------------------------------------------------------------
         def error?
           is_a?(Error)
         end

--- a/lib/crawler/data/crawl_result/redirect.rb
+++ b/lib/crawler/data/crawl_result/redirect.rb
@@ -33,7 +33,6 @@ module Crawler
         # Allow constructor to be called on concrete result classes
         public_class_method :new
 
-        #---------------------------------------------------------------------------------------------
         def to_h
           super.merge(
             location:,

--- a/lib/crawler/data/crawl_result/sitemap.rb
+++ b/lib/crawler/data/crawl_result/sitemap.rb
@@ -18,7 +18,6 @@ module Crawler
         # Allow constructor to be called on concrete result classes
         public_class_method :new
 
-        #---------------------------------------------------------------------------------------------
         # Returns links from a sitemap document as a set of URL objects
         def extract_links
           { limit_reached: false, links: { content: [], sitemap: [] } }.tap do |results|
@@ -32,7 +31,6 @@ module Crawler
           end
         end
 
-        #---------------------------------------------------------------------------------------------
         def coerce_to_links(sitemap_urls)
           sitemap_urls.map do |sitemap_url|
             # NOTE: We use the root of the site as the base, not the sitemap URL itself
@@ -43,7 +41,6 @@ module Crawler
           end
         end
 
-        #---------------------------------------------------------------------------------------------
         # Returns a sitemap parser to be used for extracting links, etc from the crawl result
         def sitemap_parser
           @sitemap_parser ||= begin

--- a/lib/crawler/data/crawl_task.rb
+++ b/lib/crawler/data/crawl_task.rb
@@ -49,9 +49,7 @@ module Crawler
         }
       end
 
-      #---------------------------------------------------------------------------------------------
       # Serialization/deserialization methods used for persisting queue items
-      #---------------------------------------------------------------------------------------------
 
       # Returns a unique identifier used to persist the object into Elasticsearch
       def unique_id
@@ -78,7 +76,6 @@ module Crawler
         )
       end
 
-      #---------------------------------------------------------------------------------------------
       def sitemap?
         type == :sitemap
       end

--- a/lib/crawler/data/link.rb
+++ b/lib/crawler/data/link.rb
@@ -36,9 +36,7 @@ module Crawler
         "<Link: base_url=#{base_url}; link=#{link.inspect}; node=#{node.inspect}; error=#{error.inspect}>"
       end
 
-      #---------------------------------------------------------------------------------------------
       # Make it possible to compare links and use them as keys in hashes and sets
-      #---------------------------------------------------------------------------------------------
       def hash
         @hash ||= [base_url, link, node].map(&:to_s).map(&:hash).sum # rubocop:disable Performance/Sum
       end
@@ -55,7 +53,6 @@ module Crawler
         other.hash == hash
       end
 
-      #---------------------------------------------------------------------------------------------
       # Returns an absolute URL for the link destination
       # Raises an Addressable::URI::InvalidURIError exception if the link is invalid or empty
       # You can call +valid?+ before converting a link to a URL if you need to make sure it is valid
@@ -68,7 +65,6 @@ module Crawler
         base_url.join(link.strip)
       end
 
-      #---------------------------------------------------------------------------------------------
       # Returns +true+ if the link is valid and could be converted to an absolute URL
       # Returns +false+ otherwise, along with setting the error value on the object
       def valid?
@@ -79,7 +75,6 @@ module Crawler
         false
       end
 
-      #---------------------------------------------------------------------------------------------
       # Returns an error message for invalid URLs, +nil+ otherwise
       def error
         # Run the validation code if we don't have an error
@@ -87,7 +82,6 @@ module Crawler
         @error
       end
 
-      #---------------------------------------------------------------------------------------------
       # Returns an array with all the values of the rel attribute for the link
       # See https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel for details
       def rel

--- a/lib/crawler/data/url_queue/base.rb
+++ b/lib/crawler/data/url_queue/base.rb
@@ -17,7 +17,6 @@ module Crawler
         # How often should we alert
         WARN_THRESHOLD_INTERVAL = 5.minutes
 
-        #-------------------------------------------------------------------------------------------
         attr_reader :config, :last_threshold_alert_timestamp
 
         delegate :crawl_id, :system_logger, to: :config
@@ -27,7 +26,6 @@ module Crawler
           raise ArgumentError, 'Needs a config' unless config
         end
 
-        #-------------------------------------------------------------------------------------------
         # Checks the size of the queue before putting any more items on it
         # Raises an exception if the queue is full
         def check_queue_size!
@@ -57,7 +55,6 @@ module Crawler
           @last_threshold_alert_timestamp = Time.now
         end
 
-        #-------------------------------------------------------------------------------------------
         # Adds one item to the queue
         def push(_item)
           check_queue_size!
@@ -85,7 +82,6 @@ module Crawler
           # nothing to do by default
         end
 
-        #-------------------------------------------------------------------------------------------
         # Returns the length of the queue
         def length
           raise NotImplementedError

--- a/lib/crawler/data/url_queue/memory_only.rb
+++ b/lib/crawler/data/url_queue/memory_only.rb
@@ -23,7 +23,6 @@ module Crawler
           setup_memory_queue
         end
 
-        #-------------------------------------------------------------------------------------------
         def setup_memory_queue
           @memory_size_limit = (config.url_queue_size_limit || 10_000).to_i
           raise ArgumentError, 'Queue size limit should be a positive number' if memory_size_limit < 1
@@ -33,7 +32,6 @@ module Crawler
           system_logger.info("Initialized an in-memory URL queue for up to #{memory_size_limit} URLs")
         end
 
-        #-------------------------------------------------------------------------------------------
         # Checks the size of the queue before putting any more items on it
         # Raises an exception if the queue is full
         def check_queue_size!
@@ -62,7 +60,6 @@ module Crawler
           )
         end
 
-        #-------------------------------------------------------------------------------------------
         # Adds an item into the queue
         def push(item)
           check_queue_size!

--- a/lib/crawler/event_generator.rb
+++ b/lib/crawler/event_generator.rb
@@ -24,7 +24,6 @@ module Crawler
       @last_stats_dump = Concurrent::AtomicReference.new(Time.at(0))
     end
 
-    #-----------------------------------------------------------------------------------------------
     # Returns the timestamp of the last crawl_status event
     def last_stats_dump
       @last_stats_dump.value
@@ -39,7 +38,6 @@ module Crawler
       crawl_status(crawl)
     end
 
-    #-----------------------------------------------------------------------------------------------
     def log_error(error, message)
       full_message = "#{message}: #{error.class}: #{error.message}"
       backtrace = error.backtrace&.join("\n")
@@ -51,9 +49,8 @@ module Crawler
       )
     end
 
-    #-----------------------------------------------------------------------------------------------
     # Crawl Lifecycle Events
-    #-----------------------------------------------------------------------------------------------
+
     def crawl_start(url_queue_items:, seen_urls:)
       resume = (url_queue_items + seen_urls).positive?
       action =
@@ -102,7 +99,6 @@ module Crawler
       )
     end
 
-    #-----------------------------------------------------------------------------------------------
     def crawl_status(crawl)
       status = crawl.status
       system_logger.info(crawl_status_for_system_log(status))
@@ -134,9 +130,8 @@ module Crawler
       "Crawl status: #{status.map { |kv| kv.join('=') }.join(', ')}"
     end
 
-    #-----------------------------------------------------------------------------------------------
     # URL Life-cycle Events
-    #-----------------------------------------------------------------------------------------------
+
     def url_seed(url:, source_url:, type:, crawl_depth:, source_type:)
       system_logger.debug(
         "Added a new URL to the crawl queue: '#{url}' (type: #{type}, source: #{source_type}, depth: #{crawl_depth})"
@@ -153,7 +148,6 @@ module Crawler
       )
     end
 
-    #-----------------------------------------------------------------------------------------------
     def url_fetch(url:, crawl_result:, auth_type: nil) # rubocop:disable Metrics/AbcSize
       status_code = crawl_result.status_code
       outcome = outcome_from_status_code(status_code)
@@ -191,7 +185,6 @@ module Crawler
       :unknown
     end
 
-    #-----------------------------------------------------------------------------------------------
     def url_discover(url:, source_url:, crawl_depth:, type:, deny_reason: nil, message: nil)
       log_url_event(
         url,
@@ -211,7 +204,6 @@ module Crawler
       url_discover(**args.merge(type: :denied))
     end
 
-    #-----------------------------------------------------------------------------------------------
     def url_extracted(url:, type:, outcome:, start_time:, end_time:, duration:, message: nil, deny_reason: nil)
       log_url_event(
         url,
@@ -227,7 +219,6 @@ module Crawler
       )
     end
 
-    #-----------------------------------------------------------------------------------------------
     def url_output(url:, sink_name:, outcome:, start_time:, end_time:, duration:, message:, output: nil)
       system_logger_severity = outcome.to_s == 'success' ? Logger::INFO : Logger::WARN
       system_logger.add(
@@ -254,7 +245,6 @@ module Crawler
       log_url_event(url, event)
     end
 
-    #-----------------------------------------------------------------------------------------------
     def url_reprocessed(url:, sink_name:, outcome:, message:, type:, output: nil)
       event = {
         'event.type' => type,
@@ -314,7 +304,6 @@ module Crawler
       }
     end
 
-    #-----------------------------------------------------------------------------------------------
     def log_url_event(url, fields)
       log_crawl_event(url_fields(url).merge(fields))
     end
@@ -329,7 +318,6 @@ module Crawler
 
     # TODO: log ingestion event
 
-    #-----------------------------------------------------------------------------------------------
     def log_event(event_info)
       log(event_info.merge('event.kind' => 'event'))
     end
@@ -338,7 +326,6 @@ module Crawler
       log(event_info.merge('event.kind' => 'metric'))
     end
 
-    #-----------------------------------------------------------------------------------------------
     def log(event_info) # rubocop:disable Metrics/AbcSize
       final_event = ecs_common_fields.merge(event_info).compact
 
@@ -361,7 +348,6 @@ module Crawler
       config.stats.update_from_event(event)
     end
 
-    #-----------------------------------------------------------------------------------------------
     # Receives a duration value and converts it into nanoseconds
     def duration_to_nanoseconds(duration)
       duration = duration.real if duration.is_a?(Benchmark::Tms)

--- a/lib/crawler/http_client.rb
+++ b/lib/crawler/http_client.rb
@@ -79,7 +79,6 @@ module Crawler
       finalize(client, :close)
     end
 
-    #-------------------------------------------------------------------------------------------------
     def head(url, headers: nil) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       raise ArgumentError, 'Need a Crawler URL object!' unless url.is_a?(Crawler::Data::URL)
 
@@ -117,7 +116,6 @@ module Crawler
       raise BaseErrorFromJava, e
     end
 
-    #-------------------------------------------------------------------------------------------------
     def get(url, headers: nil) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       raise ArgumentError, 'Need a Crawler URL object!' unless url.is_a?(Crawler::Data::URL)
 
@@ -154,12 +152,10 @@ module Crawler
       raise Crawler::HttpUtils::BaseErrorFromJava, e
     end
 
-    #-------------------------------------------------------------------------------------------------
     def connection_pool_stats
       connection_manager.total_stats
     end
 
-    #-------------------------------------------------------------------------------------------------
     def self.shutdown_on_finalize(client, objs)
       ObjectSpace.define_finalizer(
         client,
@@ -191,12 +187,10 @@ module Crawler
       builder.build
     end
 
-    #-------------------------------------------------------------------------------------------------
     def content_decoders
       CONTENT_DECODERS
     end
 
-    #-------------------------------------------------------------------------------------------------
     def new_connection_manager
       builder = PoolingHttpClientConnectionManagerBuilder.create
       builder.set_ssl_socket_factory(https_socket_factory)
@@ -208,7 +202,6 @@ module Crawler
       builder.build
     end
 
-    #-------------------------------------------------------------------------------------------------
     def https_socket_factory
       # Initialize an SSL context using a relevant st of trust managers
       ssl_context = SSLContext.get_instance('TLS')
@@ -218,7 +211,6 @@ module Crawler
       SSLConnectionSocketFactory.new(ssl_context, ssl_hostname_verifier)
     end
 
-    #-------------------------------------------------------------------------------------------------
     def ssl_trust_managers
       if config.ssl_verification_mode == 'none'
         [Crawler::HttpUtils::AllTrustingTrustManager.new]
@@ -242,7 +234,6 @@ module Crawler
       end
     end
 
-    #-------------------------------------------------------------------------------------------------
     # Adds all configured custom CA certificates to the given keystore
     # Certificates could be specified as file names or as PEM-formatted strings
     def add_custom_ca_certificates(keystore)
@@ -251,7 +242,6 @@ module Crawler
       end
     end
 
-    #-------------------------------------------------------------------------------------------------
     # Loads default Root CA certificates into the given keystore
     # Generally, the certs are loaded from JAVA_HOME/lib/cacerts
     def add_default_root_certificates(keystore)
@@ -271,7 +261,6 @@ module Crawler
       end
     end
 
-    #-------------------------------------------------------------------------------------------------
     # Returns an SSL hostname verifier instance based on our configuration
     def ssl_hostname_verifier
       case config.ssl_verification_mode
@@ -284,7 +273,6 @@ module Crawler
       end
     end
 
-    #-------------------------------------------------------------------------------------------------
     # Returns our custom DNS resolver to be used for all connections
     def dns_resolver
       Crawler::HttpUtils::FilteringDnsResolver.new(
@@ -294,7 +282,6 @@ module Crawler
       )
     end
 
-    #-------------------------------------------------------------------------------------------------
     # Returns a socket config to be used for all connections
     def default_socket_config
       builder = SocketConfig.custom
@@ -302,7 +289,6 @@ module Crawler
       builder.build
     end
 
-    #-------------------------------------------------------------------------------------------------
     # Returns a request config to be used for all connections
     def default_request_config
       builder = RequestConfig.custom
@@ -313,7 +299,6 @@ module Crawler
       builder.build
     end
 
-    #-------------------------------------------------------------------------------------------------
     # Returns a proxy host object to be used for all connections
     def proxy_host
       return nil unless config.http_proxy_host
@@ -332,7 +317,6 @@ module Crawler
       )
     end
 
-    #-------------------------------------------------------------------------------------------------
     # Returns a credentials provider to be used for all requests
     # By default, it will be empty and not have any credentials in it
     def credentials_provider
@@ -345,7 +329,6 @@ module Crawler
       end
     end
 
-    #-------------------------------------------------------------------------------------------------
     # Returns HTTP credentials to be used for proxy requests
     def proxy_credentials
       return unless config.http_proxy_username && config.http_proxy_password
@@ -356,7 +339,6 @@ module Crawler
       )
     end
 
-    #-------------------------------------------------------------------------------------------------
     # Checks the status of the connection pool and logs information about it
     def check_connection_pool_stats!
       stats = connection_pool_stats
@@ -380,7 +362,6 @@ module Crawler
       end
     end
 
-    #-------------------------------------------------------------------------------------------------
     def finalize(object, args)
       finalizers << [WeakRef.new(object), Array(args)]
     end

--- a/lib/crawler/http_executor.rb
+++ b/lib/crawler/http_executor.rb
@@ -18,7 +18,6 @@ module Crawler
       xml: %w[text/xml application/xml]
     }.freeze
 
-    #-------------------------------------------------------------------------------------------------
     attr_reader :config, :logger
 
     def initialize(config) # rubocop:disable Lint/MissingSuper
@@ -35,7 +34,7 @@ module Crawler
       }
     end
 
-    #-------------------------------------------------------------------------------------------------
+    #
     # Make sure response.release_connection is called to return unused connection back to the pool
     # see more https://frameworks.readthedocs.io/en/latest/network/http/httpClientConnectionManagement.html#connection-persistence-re-use
     def run(crawl_task, follow_redirects: false) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
@@ -101,7 +100,6 @@ module Crawler
       # rubocop:enable Metrics/BlockLength
     end
 
-    #-------------------------------------------------------------------------------------------------
     def handling_http_errors(crawl_task)
       yield
     rescue Crawler::HttpUtils::ResponseTooLarge => e
@@ -133,7 +131,7 @@ module Crawler
       )
     end
 
-    #-------------------------------------------------------------------------------------------------
+    #
     # Returns an HTTP client to be used for all requests
     def http_client
       @http_client ||= Crawler::HttpClient.new(
@@ -174,8 +172,6 @@ module Crawler
         error: "Unexpected content type #{response.content_type} for a crawl task with type=#{crawl_task.type}"
       )
     end
-
-    #-------------------------------------------------------------------------------------------------
 
     def handle_redirect(crawl_task:, response:, result_args:)
       redirect_location = response.redirect_location
@@ -269,7 +265,6 @@ module Crawler
       response.release_connection
     end
 
-    #-------------------------------------------------------------------------------------------------
     def generate_unexpected_type_crawl_result(crawl_task:, response:)
       content_type = response['content-type']
       Crawler::Data::CrawlResult::UnsupportedContentType.new(
@@ -280,7 +275,6 @@ module Crawler
       )
     end
 
-    #-------------------------------------------------------------------------------------------------
     def timeout_error(crawl_task:, exception:, error:)
       logger.error("Failed HTTP request with a timeout: #{exception.inspect}")
       Crawler::Data::CrawlResult::Error.new(
@@ -289,7 +283,6 @@ module Crawler
       )
     end
 
-    #-------------------------------------------------------------------------------------------------
     def generate_html_crawl_result(crawl_task:, response:, response_body:)
       if crawl_task.content?
         Crawler::Data::CrawlResult::HTML.new(
@@ -308,7 +301,6 @@ module Crawler
       end
     end
 
-    #-------------------------------------------------------------------------------------------------
     def generate_xml_sitemap_crawl_result(crawl_task:, response:, response_body:)
       if crawl_task.sitemap?
         Crawler::Data::CrawlResult::Sitemap.new(
@@ -327,7 +319,6 @@ module Crawler
       end
     end
 
-    #-------------------------------------------------------------------------------------------------
     def generate_content_extractable_file_crawl_result(crawl_task:, response:, response_body:)
       if SUPPORTED_MIME_TYPES[:xml].include?(response.mime_type) && crawl_task.sitemap?
         generate_xml_sitemap_crawl_result(crawl_task:, response:,
@@ -350,12 +341,10 @@ module Crawler
       end
     end
 
-    #-------------------------------------------------------------------------------------------------
     def content_extractable_file_mime_types
       config.binary_content_extraction_enabled ? config.binary_content_extraction_mime_types.map(&:downcase) : []
     end
 
-    #-------------------------------------------------------------------------------------------------
     def extractable_content
       SUPPORTED_MIME_TYPES.values.flatten + content_extractable_file_mime_types
     end

--- a/lib/crawler/http_executor.rb
+++ b/lib/crawler/http_executor.rb
@@ -131,7 +131,6 @@ module Crawler
       )
     end
 
-    #
     # Returns an HTTP client to be used for all requests
     def http_client
       @http_client ||= Crawler::HttpClient.new(

--- a/lib/crawler/http_utils/exceptions.rb
+++ b/lib/crawler/http_utils/exceptions.rb
@@ -25,7 +25,6 @@ module Crawler
 
     class InvalidHost < BaseError; end
 
-    #-----------------------------------------------------------------------------
     class InvalidEncoding < BaseError
       def new(encoding)
         @encoding = encoding
@@ -48,7 +47,6 @@ module Crawler
       end
     end
 
-    #-----------------------------------------------------------------------------
     class BaseErrorFromJava < BaseError
       attr_reader :java_exception, :root_cause
 
@@ -73,7 +71,6 @@ module Crawler
 
     class ConnectTimeout < BaseErrorFromJava; end
 
-    #-----------------------------------------------------------------------------
     class NoHttpResponseError < BaseErrorFromJava
       def self.for_proxy_host(error:, proxy_host:)
         error_class = proxy_host ? NoProxyHttpResponseError : self
@@ -95,7 +92,6 @@ module Crawler
       end
     end
 
-    #-----------------------------------------------------------------------------
     class SslException < BaseErrorFromJava
       DISABLE_SSL = 'disable SSL certificate validation (non-production environments only)'
 
@@ -131,7 +127,6 @@ module Crawler
       end
     end
 
-    #-----------------------------------------------------------------------------
     class SslCertificateExpiredError < SslException
       def error_message
         'SSL certificate expired'
@@ -142,7 +137,6 @@ module Crawler
       end
     end
 
-    #-----------------------------------------------------------------------------
     class SslCertificateNotYetValidError < SslException
       def error_message
         'SSL certificate is not yet valid'
@@ -153,7 +147,6 @@ module Crawler
       end
     end
 
-    #-----------------------------------------------------------------------------
     class SslCertificateRevokedError < SslException
       def error_message
         'SSL certificate has been revoked'
@@ -164,7 +157,6 @@ module Crawler
       end
     end
 
-    #-----------------------------------------------------------------------------
     class SslHostNameError < SslException
       def error_message
         'SSL host name issue'
@@ -175,7 +167,6 @@ module Crawler
       end
     end
 
-    #-----------------------------------------------------------------------------
     class SslHandshakeError < SslException
       def error_message
         'SSL handshake error'
@@ -186,7 +177,6 @@ module Crawler
       end
     end
 
-    #-----------------------------------------------------------------------------
     class SslCertificateChainError < SslException
       def error_message
         'SSL certificate chain is invalid'

--- a/lib/crawler/output_sink/base.rb
+++ b/lib/crawler/output_sink/base.rb
@@ -50,7 +50,6 @@ module Crawler
         # Does nothing by default.
       end
 
-      #-----------------------------------------------------------------------------------------------
       # Returns a hash with the outcome of crawl result ingestion (to be used for logging above)
       def outcome(outcome, message)
         { outcome:, message: }

--- a/lib/crawler/stats.rb
+++ b/lib/crawler/stats.rb
@@ -34,7 +34,6 @@ module Crawler
       Concurrent::Hash.new { |h, v| h[v] = Concurrent::AtomicFixnum.new(0) }
     end
 
-    #-----------------------------------------------------------------------------------------------
     # Returns the total crawl duration (in milliseconds) or nil if the crawl has not started yet
     def crawl_duration_msec
       return nil unless crawl_started_at
@@ -73,7 +72,6 @@ module Crawler
       fetched_pages_count.positive? ? time_spent_crawling_msec / fetched_pages_count : 0
     end
 
-    #-----------------------------------------------------------------------------------------------
     # Receives a crawl event (see `EventGenerator`) and updates stats based on its contents
     def update_from_event(event)
       case event['event.action']

--- a/lib/crawler/url_validator.rb
+++ b/lib/crawler/url_validator.rb
@@ -63,7 +63,6 @@ module Crawler
       request_timeout: HTTP_CHECK_TIMEOUT
     }.freeze
 
-    #-------------------------------------------------------------------------------------------------
     attr_reader :raw_url, :checks, :results, :url_crawl_result
 
     def initialize(url:, crawl_config:, checks: nil)
@@ -83,13 +82,11 @@ module Crawler
       @results = []
     end
 
-    #-------------------------------------------------------------------------------------------------
     # Returns a list of check names that are valid for a given validator configuration
     def valid_checks
       DOMAIN_LEVEL_CHECKS
     end
 
-    #-------------------------------------------------------------------------------------------------
     # Validates a given domain, returns +true+ if the domain is valid, +false+ otherwise
     # Detailed results could be retrieved by calling `#results`
     def valid?

--- a/lib/crawler/url_validator/url_content_check_concern.rb
+++ b/lib/crawler/url_validator/url_content_check_concern.rb
@@ -53,7 +53,6 @@ module Crawler
       end
     end
 
-    #-------------------------------------------------------------------------------------------------
     def validation_warn_from_crawl_redirect
       location = url_crawl_result.location.to_s
       validation_warn(:url_content, <<~MESSAGE, location:)
@@ -63,7 +62,6 @@ module Crawler
       MESSAGE
     end
 
-    #-------------------------------------------------------------------------------------------------
     def validation_fail_from_crawl_error
       error_happened =
         if url_crawl_result.instance_of?(Crawler::Data::CrawlResult::Error)

--- a/lib/crawler/url_validator/url_request_check_concern.rb
+++ b/lib/crawler/url_validator/url_request_check_concern.rb
@@ -98,7 +98,6 @@ module Crawler
       end
     end
 
-    #-------------------------------------------------------------------------------------------------
     def redirect_validation_result(details) # rubocop:disable Metrics/AbcSize
       location = url_crawl_result.location
 


### PR DESCRIPTION
The Open Crawler codebase is full of line break comments that look like:

```
# ----------------------------------------
```

The code base would look cleaner if we didn't have these, so this PR removes them.

### Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] This PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `crawler.yml.example` and `elasticsearch.yml.example`)
- [x] This PR has a meaningful title
- [x] This PR links to all relevant GitHub issues that it fixes or partially addresses
    - If there is no GitHub issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Tested the changes locally