### PR TITLE
File sink generates human-readable filenames

### DIFF
--- a/lib/crawler/output_sink/file.rb
+++ b/lib/crawler/output_sink/file.rb
@@ -22,9 +22,19 @@ module Crawler
         FileUtils.mkdir_p(dir)
       end
 
+      def generate_filename_from_url(crawl_result)
+        url_filename = crawl_result.url.to_s
+        url_filename = url_filename.chop if url_filename.end_with?('/') # trim tailing slash if present
+
+        url_filename
+          .gsub(/[^a-zA-Z0-9\-_]/, '_') # replace slashes with underscores
+          .squeeze('_') # remove repetitive underscores
+          .gsub(/^https?_?(www_)?/, '') # remove scheme and www
+      end
+
       def write(crawl_result)
         doc = to_doc(crawl_result)
-        result_file = "#{dir}/#{crawl_result.url_hash}.json"
+        result_file = "#{dir}/#{generate_filename_from_url(crawl_result)}.json"
         ::File.write(result_file, doc.to_json)
 
         success

--- a/lib/crawler/output_sink/file.rb
+++ b/lib/crawler/output_sink/file.rb
@@ -23,13 +23,24 @@ module Crawler
       end
 
       def generate_filename_from_url(crawl_result)
-        url_filename = crawl_result.url.to_s
-        url_filename = url_filename.chop if url_filename.end_with?('/') # trim tailing slash if present
+        full_url = crawl_result.url.to_s
+        full_url = full_url.chop if full_url.end_with?('/') # trim tailing slash if present
 
-        url_filename
-          .gsub(/[^a-zA-Z0-9\-_]/, '_') # replace slashes with underscores
-          .squeeze('_') # remove repetitive underscores
-          .gsub(/^https?_?(www_)?/, '') # remove scheme and www
+        filename = full_url
+                   .gsub(/[^a-zA-Z0-9\-_]/, '_') # replace slashes with underscores
+                   .squeeze('_') # remove repetitive underscores
+                   .gsub(/^https?_?(www_)?/, '') # remove scheme and www
+
+        # Most OSes limit filenames to 256 chars, we should truncate if too long
+        if filename.length > 255
+          # 128 + 122 = 250 chars, leaving 6 chars for the file extension (.json)
+          starting_idx = 128
+          ending_idx = filename.length - 122
+          # slice out the middle to retain the domain and more unique paths at the end of the URL
+          filename.slice!(starting_idx..ending_idx)
+        end
+
+        filename
       end
 
       def write(crawl_result)

--- a/lib/crawler/output_sink/file.rb
+++ b/lib/crawler/output_sink/file.rb
@@ -34,7 +34,9 @@ module Crawler
 
       def write(crawl_result)
         doc = to_doc(crawl_result)
-        result_file = "#{dir}/#{generate_filename_from_url(crawl_result)}.json"
+        document_filename = "#{generate_filename_from_url(crawl_result)}.json"
+        system_logger.debug("Writing crawled document to #{dir}/#{document_filename}")
+        result_file = "#{dir}/#{document_filename}"
         ::File.write(result_file, doc.to_json)
 
         success

--- a/spec/lib/crawler/output_sink/file_spec.rb
+++ b/spec/lib/crawler/output_sink/file_spec.rb
@@ -35,4 +35,38 @@ RSpec.describe(Crawler::OutputSink::File) do
       new_sink(config)
     end
   end
+
+  context 'filename generation' do
+    config = Crawler::API::Config.new(
+      domains: [{ url: 'https://example.com' }],
+      output_sink: 'file'
+    )
+    let(:sink) { Crawler::OutputSink::File.new(config) }
+    def create_crawl_result(url)
+      url_obj = Crawler::Data::URL.parse(url)
+      double('crawl_result', url: url_obj)
+    end
+
+    it 'removes slashes, spaces, and http/https/www prefixes' do
+      test_cases = {
+        'https://example.com/path/to/page/' => 'example_com_path_to_page',
+        'https://www.test.com/some page.html/' => 'test_com_some_page_html',
+        'https://sub.domain.com/path//double/slash/' => 'sub_domain_com_path_double_slash',
+        'http://www.example.com' => 'example_com', # NOTE: the lack of trailing slash in the original URL
+        'https://www.complex-url.com/path?param=value#fragment/' => 'complex-url_com_path_param_value_fragment'
+      }
+
+      test_cases.each do |input, expected|
+        crawl_result = create_crawl_result(input)
+        result = sink.generate_filename_from_url(crawl_result)
+
+        expect(result).to eq(expected)
+        expect(result).not_to include('/')
+        expect(result).not_to include(' ')
+        expect(result).not_to match(/^https?_/)
+        expect(result).not_to match(/^www_/)
+        expect(result).not_to end_with('_')
+      end
+    end
+  end
 end

--- a/spec/lib/crawler/output_sink/file_spec.rb
+++ b/spec/lib/crawler/output_sink/file_spec.rb
@@ -6,6 +6,7 @@
 
 # frozen_string_literal: true
 
+# rubocop:disable Layout/LineLength
 RSpec.describe(Crawler::OutputSink::File) do
   let(:domains) { [{ url: 'http://example.com' }] }
 
@@ -52,8 +53,11 @@ RSpec.describe(Crawler::OutputSink::File) do
         'https://example.com/path/to/page/' => 'example_com_path_to_page',
         'https://www.test.com/some page.html/' => 'test_com_some_page_html',
         'https://sub.domain.com/path//double/slash/' => 'sub_domain_com_path_double_slash',
-        'http://www.example.com' => 'example_com', # NOTE: the lack of trailing slash in the original URL
-        'https://www.complex-url.com/path?param=value#fragment/' => 'complex-url_com_path_param_value_fragment'
+        'http://www.example.com' => 'example_com', # NOTE: there is no trailing slash in this URL
+        'https://www.complex-url.com/path?param=value#fragment/' => 'complex-url_com_path_param_value_fragment',
+        # the following looks scary, but it's just a long URL (over 256 characters) to test truncation
+        'https://www.long-url.com/path?param=value#over-two-fifty-six-chars/this-should-be-truncated-to-only-be-two-hundred/and-fifty-six-chars-long/this-should-be-truncated-to-only-be-two-hundred/and-fifty-six-chars-long/the-tail-end-is-unique-and-must-be-preserved' =>
+          'long-url_com_path_param_value_over-two-fifty-six-chars_this-should-be-truncated-to-only-be-two-hundred_and-fifty-six-chars-long_this-should-be-truncated-to-only-be-two-hundred_and-fifty-six-chars-long_the-tail-end-is-unique-and-must-be-preserved'
       }
 
       test_cases.each do |input, expected|
@@ -68,5 +72,6 @@ RSpec.describe(Crawler::OutputSink::File) do
         expect(result).not_to end_with('_')
       end
     end
+    # rubocop:enable Layout/LineLength
   end
 end


### PR DESCRIPTION
### Closes https://github.com/elastic/crawler/issues/298

This PR aims to make the File sink generate human-readable `json` files as opposed to the hash values it was previously using. The hash values were not human readable, which makes understanding their contents at a glance impossible.

Here is an example of the filenames with this change:
![1033E9FF-73E0-422C-AA31-0610C0FD3A12](https://github.com/user-attachments/assets/75807074-bfac-4211-9890-0f6c4cdab641)

### Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] This PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `crawler.yml.example` and `elasticsearch.yml.example`)
- [x] This PR has a meaningful title
- [x] This PR links to all relevant GitHub issues that it fixes or partially addresses
    - If there is no GitHub issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v0.1.0`)
- [x] Considered corresponding documentation changes