### PR TITLE
Replaced links to ent-search docs with links to Crawler example config

### DIFF
--- a/lib/crawler/url_validator/url_request_check_concern.rb
+++ b/lib/crawler/url_validator/url_request_check_concern.rb
@@ -65,7 +65,7 @@ module Crawler
         validation_fail(:url_request, <<~MESSAGE, details)
           The web server at #{url} is configured to require an HTTP proxy for access (HTTP 407).
           This may mean that you're trying to index an internal (intranet) server.
-          You can configure proxy settings in your configuration here: https://github.com/elastic/crawler/blob/0a5ab5b74eae12f96b312d7cea39103a64b28700/config/crawler.yml.example#L150..
+          You can configure proxy settings in your configuration here: https://github.com/elastic/crawler/blob/0a5ab5b74eae12f96b312d7cea39103a64b28700/config/crawler.yml.example#L150.
         MESSAGE
 
       when 429

--- a/lib/crawler/url_validator/url_request_check_concern.rb
+++ b/lib/crawler/url_validator/url_request_check_concern.rb
@@ -43,7 +43,7 @@ module Crawler
         validation_fail(:url_request, <<~MESSAGE, details)
           The web server at #{url} is configured to require an HTTP proxy for access (HTTP 305).
           This may mean that you're trying to index an internal (intranet) server.
-          Read more at: https://www.elastic.co/guide/en/enterprise-search/current/crawler-private-network-cloud.html.
+          You can configure proxy settings in your configuration here: https://github.com/elastic/crawler/blob/0a5ab5b74eae12f96b312d7cea39103a64b28700/config/crawler.yml.example#L150.
         MESSAGE
 
       when 401
@@ -53,7 +53,7 @@ module Crawler
         validation_fail(:url_request, <<~MESSAGE, details)
           The web server at #{url} denied us permission to view that page (HTTP 403).
           This website may require a user name and password.
-          Read more at: https://www.elastic.co/guide/en/enterprise-search/current/crawler-managing.html#crawler-managing-authentication.
+          You can configure authentication settings in your configuration here: https://github.com/elastic/crawler/blob/0a5ab5b74eae12f96b312d7cea39103a64b28700/config/crawler.yml.example#L187.
         MESSAGE
 
       when 404
@@ -65,7 +65,7 @@ module Crawler
         validation_fail(:url_request, <<~MESSAGE, details)
           The web server at #{url} is configured to require an HTTP proxy for access (HTTP 407).
           This may mean that you're trying to index an internal (intranet) server.
-          Read more at: https://www.elastic.co/guide/en/enterprise-search/current/crawler-private-network-cloud.html.
+          You can configure proxy settings in your configuration here: https://github.com/elastic/crawler/blob/0a5ab5b74eae12f96b312d7cea39103a64b28700/config/crawler.yml.example#L150..
         MESSAGE
 
       when 429
@@ -153,14 +153,14 @@ module Crawler
       if ::SharedTogo::Crawler2.license_allows_authenticated_crawls?
         validation_warn(:url_request, <<~MESSAGE, details)
           #{shared_message};
-          remember to configure auth for the associated domain.
-          Read more at: https://www.elastic.co/guide/en/enterprise-search/current/crawler-managing.html#crawler-managing-authentication.
+          Remember to configure auth for the associated domain.
+          You can configure authentication setting in your configuration here: https://github.com/elastic/crawler/blob/0a5ab5b74eae12f96b312d7cea39103a64b28700/config/crawler.yml.example#L187.
         MESSAGE
       else
         validation_fail(:url_request, <<~MESSAGE, details)
           #{shared_message}.
           #{::Crawler::AUTHENTICATED_CRAWL_LICENSE_ERROR}.
-          Read more at: https://www.elastic.co/guide/en/enterprise-search/current/crawler-managing.html#crawler-managing-authentication.
+          You can configure authentication setting in your configuration here: https://github.com/elastic/crawler/blob/0a5ab5b74eae12f96b312d7cea39103a64b28700/config/crawler.yml.example#L187.
         MESSAGE
       end
     end

--- a/spec/lib/crawler/url_validator/url_request_check_spec.rb
+++ b/spec/lib/crawler/url_validator/url_request_check_spec.rb
@@ -79,10 +79,9 @@ RSpec.describe(Crawler::UrlValidator) do
         expect(validator)
           .to receive(:validation_fail)
           .with(:url_request,
-                "The web server at #{valid_url} denied us permission to view that page (HTTP 403).\nThis website " \
-                "may require a user name and password.\nRead more at: " \
-                'https://www.elastic.co/guide/en/enterprise-search/current/crawler-managing.html' \
-                "#crawler-managing-authentication.\n",
+                "The web server at #{valid_url} denied us permission to view that page (HTTP 403).\n" \
+                "This website may require a user name and password.\n" \
+                "You can configure authentication settings in your configuration here: https://github.com/elastic/crawler/blob/0a5ab5b74eae12f96b312d7cea39103a64b28700/config/crawler.yml.example#L187.\n",
                 hash_including(:status_code, :content_type, :request_time_msec))
         validator.validate_url_request
       end
@@ -109,8 +108,8 @@ RSpec.describe(Crawler::UrlValidator) do
           .to receive(:validation_fail)
           .with(:url_request,
                 "The web server at #{valid_url} is configured to require an HTTP proxy for access (HTTP 407).\n" \
-                "This may mean that you're trying to index an internal (intranet) server.\nRead more at: " \
-                "https://www.elastic.co/guide/en/enterprise-search/current/crawler-private-network-cloud.html.\n",
+                "This may mean that you're trying to index an internal (intranet) server.\n" \
+                "You can configure proxy settings in your configuration here: https://github.com/elastic/crawler/blob/0a5ab5b74eae12f96b312d7cea39103a64b28700/config/crawler.yml.example#L150.\n",
                 hash_including(:status_code, :content_type, :request_time_msec))
         validator.validate_url_request
       end


### PR DESCRIPTION
### Closes https://github.com/elastic/crawler/issues/178

This PR replaces some links to Enterprise Search docs in the codebase to links to Open Crawler's configuration docs.

This isn't perfect (ideally we should point to docs of our own explaining proxy setup, auth config etc) but this at least gets mentions of `ent-search` out of Open Crawler.

If Open Crawler gets documentation for these specific features, these links to be updated to point to those.

### Checklists

#### Pre-Review Checklist
- [x] This PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `crawler.yml.example` and `elasticsearch.yml.example`)
- [x] This PR has a meaningful title
- [x] This PR links to all relevant GitHub issues that it fixes or partially addresses
    - If there is no GitHub issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v0.1.0`)