### PR TITLE
init commit for JWT auth

### DIFF
--- a/config/crawler.yml.example
+++ b/config/crawler.yml.example
@@ -184,13 +184,7 @@
 #   ...CERT DATA...
 #   -----END CERTIFICATE-----
 #
-## Authentication configurations.
-##     Only required if a site has some form of authentication.
-#auth.domain: https://my-auth-domain.com
-#auth.type: basic
-#auth.username: user
-#auth.password: pass
-#
+
 ## Whether document metadata from certain content types will be indexed or not.
 ##     This does not allow binary content to be indexed from these files, only metadata.
 ##     See docs/features/BINARY_CONTENT_EXTRACTION.md for more details.
@@ -202,6 +196,27 @@
 #  - application/vnd.ms-powerpoint
 #  - application/vnd.openxmlformats-officedocument.presentationml.presentation
 #
+
+## ------------------------------- Authentication ------------------------------
+##Only required if a site has some form of authentication.
+
+##   Domain is required for all authentication configurations
+#auth.domain: https://my-auth-domain.com
+
+##  Type can be one of three settings:
+##    raw | basic | jwt
+#auth.type: basic
+
+##  Raw auth requires the following:
+#auth.header: your-header-here
+
+##  Basic authentication, requires username and password:
+#auth.username: user
+#auth.password: pass
+
+##  JWT authentication requires the JWT token you wish to use:
+#auth.jwt_token: your-jwt-token-here
+
 ## ------------------------------- Logging -------------------------------------
 #
 ## The log level for system logs. Defaults to `info`


### PR DESCRIPTION
### Closes https://github.com/elastic/search-team/issues/9783

This PR implements bring-your-own JWT authentication to Open Crawler.

Currently, Open Crawler only supports basic auth with `username` and `password`.

With these changes, users will be able to supply an encrypted JWT token via config for Open Crawler to pass to each website call's `Authentication` header.

With these changes, 

### Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] This PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `crawler.yml.example` and `elasticsearch.yml.example`)
- [x] This PR has a meaningful title
- [x] This PR links to all relevant GitHub issues that it fixes or partially addresses
    - If there is no GitHub issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v0.1.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference
