### PR TITLE
Support internationalized domain names and paths

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,9 @@ Metrics/ModuleLength:
 Metrics/AbcSize:
   Max: 20
 
+Metrics/CyclomaticComplexity:
+  Max: 8
+
 # Disable for specs
 Metrics/BlockLength:
   Exclude:

--- a/lib/crawler/api/config.rb
+++ b/lib/crawler/api/config.rb
@@ -341,9 +341,6 @@ module Crawler
 
       def normalize_domain!(domain)
         # Pre-emptively normalize all domain / seed URLs so we don't run into encoding issues later
-        raise ArgumentError, 'Each domain requires a url' unless domain[:url]
-
-        # Remove the path from top-level domains as they aren't used for seeding
         domain[:url] = normalize_url(domain[:url], remove_path: true)
         domain[:seed_urls].map! { |seed_url| normalize_url(seed_url) } if domain[:seed_urls]&.any?
         domain[:sitemap_urls].map! { |sitemap_url| normalize_url(sitemap_url) } if domain[:sitemap_urls]&.any?
@@ -351,6 +348,7 @@ module Crawler
 
       def normalize_url(url, remove_path: false)
         normalized_url = Addressable::URI.parse(url).normalize
+        # Remove the path from top-level domains as they aren't used for seeding
         normalized_url.path = '' if remove_path
 
         system_logger.info("Normalized URL #{url} as #{normalized_url}")

--- a/lib/crawler/api/config.rb
+++ b/lib/crawler/api/config.rb
@@ -351,7 +351,7 @@ module Crawler
         # Remove the path from top-level domains as they aren't used for seeding
         normalized_url.path = '' if remove_path
 
-        system_logger.info("Normalized URL #{url} as #{normalized_url}")
+        system_logger.debug("Normalized URL #{url} as #{normalized_url}")
         normalized_url.to_s
       end
 

--- a/lib/crawler/api/config.rb
+++ b/lib/crawler/api/config.rb
@@ -335,11 +335,8 @@ module Crawler
 
         # Remove the path from top-level domains as they aren't used for seeding
         domain[:url] = normalize_url(domain[:url], remove_path: true)
-        return unless domain[:seed_urls]&.any?
-
-        domain[:seed_urls].map! do |seed_url|
-          normalize_url(seed_url)
-        end
+        domain[:seed_urls].map! { |seed_url| normalize_url(seed_url) } if domain[:seed_urls]&.any?
+        domain[:sitemap_urls].map! { |sitemap_url| normalize_url(sitemap_url) } if domain[:sitemap_url]&.any?
       end
 
       def normalize_url(url, remove_path: false)

--- a/lib/crawler/api/config.rb
+++ b/lib/crawler/api/config.rb
@@ -346,7 +346,7 @@ module Crawler
         # Remove the path from top-level domains as they aren't used for seeding
         domain[:url] = normalize_url(domain[:url], remove_path: true)
         domain[:seed_urls].map! { |seed_url| normalize_url(seed_url) } if domain[:seed_urls]&.any?
-        domain[:sitemap_urls].map! { |sitemap_url| normalize_url(sitemap_url) } if domain[:sitemap_url]&.any?
+        domain[:sitemap_urls].map! { |sitemap_url| normalize_url(sitemap_url) } if domain[:sitemap_urls]&.any?
       end
 
       def normalize_url(url, remove_path: false)

--- a/lib/crawler/api/config.rb
+++ b/lib/crawler/api/config.rb
@@ -350,9 +350,10 @@ module Crawler
         normalized_url = Addressable::URI.parse(url).normalize
         # Remove the path from top-level domains as they aren't used for seeding
         normalized_url.path = '' if remove_path
+        normalized_url_str = normalized_url.to_s
 
-        system_logger.debug("Normalized URL #{url} as #{normalized_url}")
-        normalized_url.to_s
+        system_logger.info("Normalized URL #{url} as #{normalized_url_str}") if url != normalized_url_str
+        normalized_url_str
       end
 
       def configure_crawl_rules!

--- a/lib/crawler/content_engine/transformer.rb
+++ b/lib/crawler/content_engine/transformer.rb
@@ -28,7 +28,7 @@ module Crawler
         doc
       end
 
-      def self.traverse!(node, mode:) # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      def self.traverse!(node, mode:) # rubocop:disable Metrics/MethodLength, Metrics/PerceivedComplexity
         # The exclusion attribute is used to determine what to traverse next in the parent loop,
         # so we should remove the attribute while traversing to avoid an infinite loop.
         node.remove_attribute(EXCLUDE_ATTR) if node.has_attribute?(EXCLUDE_ATTR)

--- a/lib/crawler/http_header_service.rb
+++ b/lib/crawler/http_header_service.rb
@@ -66,7 +66,7 @@ module Crawler
       @auth = auth
     end
 
-    def authorization_header_for_url(url) # rubocop:disable Metrics/CyclomaticComplexity
+    def authorization_header_for_url(url)
       raise ArgumentError, 'Need a Crawler URL object!' unless url.is_a?(Crawler::Data::URL)
 
       match = auth&.find { |item| item.fetch('domain') == url.site }

--- a/lib/crawler/rule_engine/base.rb
+++ b/lib/crawler/rule_engine/base.rb
@@ -62,7 +62,7 @@ module Crawler
         end
       end
 
-      def output_crawl_result_outcome(crawl_result) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
+      def output_crawl_result_outcome(crawl_result) # rubocop:disable Metrics/AbcSize
         unless crawl_result.is_a?(Crawler::Data::CrawlResult::Base)
           raise ArgumentError,
                 'Needs a Crawler::Data::CrawlResult::Base object'

--- a/lib/crawler/url_validator/dns_check_concern.rb
+++ b/lib/crawler/url_validator/dns_check_concern.rb
@@ -27,7 +27,7 @@ module Crawler
                           ])
 
       # Check DNS
-      addresses = resolv.getaddresses(url.host)
+      addresses = resolv.getaddresses(url.normalized_host)
 
       if addresses.empty?
         validation_fail(:dns, 'DNS name resolution failed. No suitable addresses found!')

--- a/spec/lib/crawler/api/config_spec.rb
+++ b/spec/lib/crawler/api/config_spec.rb
@@ -67,6 +67,28 @@ RSpec.describe(Crawler::API::Config) do
       expect(config.output_dir).to eq('./crawled_docs')
     end
 
+    context 'when a domain has an internationalized domain name' do
+      let(:domain2) do
+        {
+          url: 'https://ポケモン.com',
+          seed_urls: %w[https://ポケモン.com/問い合わせ]
+        }
+      end
+
+      let(:normalized_domain) { 'https://xn--rckteqa2e.com' }
+      let(:normalized_seed_url) { 'https://xn--rckteqa2e.com/%E5%95%8F%E3%81%84%E5%90%88%E3%82%8F%E3%81%9B' }
+
+      let(:expected_allowlist) { %W[#{domain1[:url]}:443 #{normalized_domain}:443] }
+      let(:expected_seed_urls) { domain1[:seed_urls] + [normalized_seed_url] }
+
+      it 'should normalize the URL and any seed URLs' do
+        config = Crawler::API::Config.new(domains:)
+
+        expect(config.domain_allowlist.map(&:to_s)).to match_array(expected_allowlist)
+        expect(config.seed_urls.map(&:to_s).to_a).to match_array(expected_seed_urls)
+      end
+    end
+
     context 'when a domain is missing a main URL' do
       let(:domain2) { { foo: 'bar' } }
 


### PR DESCRIPTION
### Part of https://github.com/elastic/crawler/issues/315

Add support for domain names and paths that use a different formatting (e.g.: UTF-8 instead of ASCII).

Changes:

- Normalize all domains, seed URLs, and sitemap URLs during initial config building stage
    - This is done by overwriting the existing URL in memory, so the normalized one will be used everywhere else in the crawl run
- Use Addressable instead of ruby's built-in URI lib to parse config URLs
- Use normalized URL when using validate CLI command
- [Lint] Increase cyclomatic complexity from 7 to 8
