### PR TITLE
Fix release pipeline directory test

### DIFF
--- a/.buildkite/publish/test-docker.sh
+++ b/.buildkite/publish/test-docker.sh
@@ -80,7 +80,7 @@ commandTests:
     args: ["--version"]
     expectedOutput: ["jruby\\s9\\.4\\.*"]
   - name: "Crawler installation"
-    command: "/app/bin/crawler"
+    command: "/home/app/bin/crawler"
     args: ["--version"]
     expectedOutput: ["'"${ESCAPED_VERSION}"'*"]
 '


### PR DESCRIPTION
The directory was changed from `/app` to `/home/app` on both the main and 0.2 branches, but this test was only fixed for main branch.
This PR fixes the test for the 0.2 branch so 0.2.x versions can continue to be released.