### PR TITLE
Make ES hosts config an array

### DIFF
--- a/lib/crawler/output_sink/elasticsearch.rb
+++ b/lib/crawler/output_sink/elasticsearch.rb
@@ -58,8 +58,9 @@ module Crawler
         system_logger.info(
           "Connected to ES at #{es_host} - version: #{version}; build flavor: #{build_flavor}"
         )
-      rescue Elastic::Transport::Transport::Error # rescue bc client.info crashes ungracefully when ES is unreachable
-        system_logger.info("Failed to reach ES at #{es_host}")
+      rescue Elastic::Transport::Transport::Error => e
+        # rescue bc client.info crashes ungracefully when ES is unreachable
+        system_logger.info("Failed to reach ES at #{es_host}: #{e}")
         raise Errors::ExitIfESConnectionError
       end
 

--- a/lib/es/client.rb
+++ b/lib/es/client.rb
@@ -106,10 +106,14 @@ module ES
       port ||= uri.port
 
       {
-        scheme:,
-        host:,
-        port:
-      }.compact
+        hosts: [
+          {
+            scheme:,
+            host:,
+            port:
+          }.compact
+        ]
+      }
     end
 
     def get_retry_configuration(es_config)


### PR DESCRIPTION
### Closes https://github.com/elastic/crawler/issues/301

In 0.2.x, if `elasticsearch.ca_fingerprint` was provided we would dynamically set `verify_ssl: false` for the ES client.
In 0.3.x, we have a new config option `elasticsearch.verify_ssl` so the user can toggle this themselves. However, this breaks the existing CA fingerprint usage.

_Why does using an array work?_ I honestly don't know. However, official documentation for the ruby client has hosts defined in an array. It's possible defining a single host is a legacy method, and some support for it has not kept up compared to an array of hosts.

Ultimately, defining an array of `hosts` (with a single host item) will perform the same functionality as defining a single `host`, so I believe this change is worth doing just to fix CA fingerprint configuration.

---

🚫  Output when defining a single host (fails with cryptic error about using http):

```
[2025-07-02T15:54:39.702Z] [crawl:68653a1fff0236cc731674a2] [primary] Initialized an in-memory URL queue for up to 10000 URLs
[2025-07-02T15:54:39.706Z] [crawl:68653a1fff0236cc731674a2] [primary] Elasticsearch client retry configuration: 3 retries with 2s delay
[2025-07-02T15:54:39.707Z] [crawl:68653a1fff0236cc731674a2] [primary] ES connections will be authorized with configured API key
[2025-07-02T15:54:39.707Z] [crawl:68653a1fff0236cc731674a2] [primary] ES connection SSL config: {:ca_fingerprint=>"B36EDC42B9073217CF47B6A0558C760A39B896BFE5A07BEEB8C86C0F4667A6A8", :transport_options=>{:ssl=>{:verify=>true}}}
[2025-07-02T15:54:39.707Z] [crawl:68653a1fff0236cc731674a2] [primary] ES connection compression is enabled
The client is unable to verify that the server is Elasticsearch. Some functionality may not be compatible if the server is running an unsupported product.
[2025-07-02T15:54:39.714Z] [crawl:68653a1fff0236cc731674a2] [primary] Failed to reach ES at https://nav-test-9-1-0.es.us-west2.gcp.elastic-cloud.com:443:: CA fingerprinting can't be configured over http
```

✅  Output when defining an array of hosts (with a single host item) (succeeds!):

```
[2025-07-02T15:53:45.739Z] [crawl:686539e9ff02369ca9e8e195] [primary] Initialized an in-memory URL queue for up to 10000 URLs
[2025-07-02T15:53:45.743Z] [crawl:686539e9ff02369ca9e8e195] [primary] Elasticsearch client retry configuration: 3 retries with 2s delay
[2025-07-02T15:53:45.744Z] [crawl:686539e9ff02369ca9e8e195] [primary] ES connections will be authorized with configured API key
[2025-07-02T15:53:45.744Z] [crawl:686539e9ff02369ca9e8e195] [primary] ES connection SSL config: {:ca_fingerprint=>"B36EDC42B9073217CF47B6A0558C760A39B896BFE5A07BEEB8C86C0F4667A6A8", :transport_options=>{:ssl=>{:verify=>true}}}
[2025-07-02T15:53:45.744Z] [crawl:686539e9ff02369ca9e8e195] [primary] ES connection compression is enabled
[2025-07-02T15:53:47.630Z] [crawl:686539e9ff02369ca9e8e195] [primary] Connected to ES at https://nav-test-9-1-0.es.us-west2.gcp.elastic-cloud.com:443: - version: 9.1.0; build flavor: default
```