### PR TITLE
Add IRB console executable

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Set up an IRB console with Crawler classes fully imported
+# Require enviment.rb which pulls in the full Crawler codebase + dependencies
+require_relative File.expand_path('../../lib/environment', __FILE__)
+require 'irb'
+IRB.start(__FILE__)


### PR DESCRIPTION
Add executable for easier debugging.
Calling `bin/console` will spin up an IRB session that has already imported the entire Crawler codebase, allowing targeted testing or debugging of different classes/methods/modules.