### PR TITLE
Build the wolfi image on CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,3 +21,8 @@ steps:
     commands:
       - ".buildkite/scripts/run_command.sh docker"
       - ".buildkite/scripts/run_command.sh test"
+  - label: ":wolfi: Test Wolfi Image"
+    commands:
+      - ".buildkite/scripts/run_command.sh wolfi"
+      - "chmod +x .buildkite/scripts/test-wolfi-image.sh"
+      - ".buildkite/scripts/test-wolfi-image.sh"

--- a/.buildkite/scripts/run_command.sh
+++ b/.buildkite/scripts/run_command.sh
@@ -23,6 +23,9 @@ SCRIPT_CMD="/ci/.buildkite/scripts/run_ci_step.sh"
 if [[ "${COMMAND_TO_RUN:-}" == "docker" ]]; then
   echo "---- running docker build"
   make build-docker-ci
+elif [[ "${COMMAND_TO_RUN:-}" == "wolfi" ]]; then
+  echo "---- running wolfi docker build"
+  make build-docker-wolfi
 else
   docker run --interactive --rm             \
               --sig-proxy=true --init      \

--- a/.buildkite/scripts/test-wolfi-image.sh
+++ b/.buildkite/scripts/test-wolfi-image.sh
@@ -7,6 +7,6 @@ echo "Testing JRuby installation..."
 docker run --rm crawler-ci-wolfi ruby --version | grep -E "jruby\s9\.4\..*"
 
 echo "Testing crawler installation..."
-docker run --rm crawler-ci-wolfi /home/app/bin/crawler --version
+docker run --rm crawler-ci-wolfi /home/app/bin/crawler version
 
 echo "Wolfi image tests passed!"

--- a/.buildkite/scripts/test-wolfi-image.sh
+++ b/.buildkite/scripts/test-wolfi-image.sh
@@ -7,6 +7,6 @@ echo "Testing JRuby installation..."
 docker run --rm crawler-ci-wolfi ruby --version | grep -E "jruby\s9\.4\..*"
 
 echo "Testing crawler installation..."
-docker run --rm crawler-ci-wolfi /home/app/bin/crawler version
+docker run --rm crawler-ci-wolfi jruby bin/crawler version
 
 echo "Wolfi image tests passed!"

--- a/.buildkite/scripts/test-wolfi-image.sh
+++ b/.buildkite/scripts/test-wolfi-image.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# Simple tests to verify Wolfi image functionality
+echo "Testing JRuby installation..."
+docker run --rm crawler-ci-wolfi ruby --version | grep -E "jruby\s9\.4\..*"
+
+echo "Testing crawler installation..."
+docker run --rm crawler-ci-wolfi /home/app/bin/crawler --version
+
+echo "Wolfi image tests passed!"

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,5 +1,5 @@
 # Build stage
-FROM docker.elastic.co/wolfi/jdk:openjdk-21.35-r1@sha256:d7ca36452a68f28e4c4683062241e817b548844820a0ffd087451214e61eb188 AS builder
+FROM docker.elastic.co/wolfi/jdk:openjdk-21.35-r1@sha256:56d69799450d02a898e3e6c3ffd2cd5f34931788abdf6a102d07035bcae0d3d3 AS builder
 
 USER root
 
@@ -55,7 +55,7 @@ RUN rm -rf .git .github .idea .devcontainer .buildkite
 
 # ------------------------------------------------------------------------------
 # Runtime stage - using the same base image
-FROM docker.elastic.co/wolfi/jdk:openjdk-21.35-r1@sha256:d7ca36452a68f28e4c4683062241e817b548844820a0ffd087451214e61eb188
+FROM docker.elastic.co/wolfi/jdk:openjdk-21.35-r1@sha256:56d69799450d02a898e3e6c3ffd2cd5f34931788abdf6a102d07035bcae0d3d3
 
 USER root
 

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ notice:
 build-docker-ci:
 	docker build -t crawler-ci .
 
+build-docker-wolfi:
+	docker build -t crawler-ci-wolfi -f Dockerfile.wolfi .
+
 list-gems:
 	script/bundle exec gem dependency
 


### PR DESCRIPTION
### Description

`elastic-renovate` recently [bumped](https://github.com/elastic/crawler/pull/349) the sha for the base image of our wolfi docker image. Unfortunately that broke our image as `apk` has been stripped out, which requires a re-work of the Dockerfile. The regression slipped through the cracks because on CI we only build the simple Docker image (`Dockerfile`), not the wolfi one. Wolfi is only built at release time.

I tried a few different things to fix the new image, however it seems like it's a non-trivial amount of effort at this time, so we just [reverted the bump](https://github.com/elastic/crawler/pull/358). 
For future reference, I tried using `wget` instead of `curl`, as well as installing `curl` and `make` via another build stage (from an `alpine` image, and copy it into the next stages). For example kept running into issues making `make` work

```
 > [builder 14/15] RUN make clean install:
0.116 rm -rf Jars.lock vendor/jars
0.158 script/environment
0.158 make: script/environment: No such file or directory
0.158 make: *** [Makefile:13: install] Error 127
```

### Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [ ] This PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `crawler.yml.example` and `elasticsearch.yml.example`)
- [ ] This PR has a meaningful title
- [ ] This PR links to all relevant GitHub issues that it fixes or partially addresses
    - If there is no GitHub issue, please create it. Each PR should have a link to an issue
- [ ] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [ ] Tested the changes locally
- [ ] Added a label for each target release version (example: `v0.1.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] Ran `make notice` if any dependencies have been added

### Related Pull Requests

<!--List any relevant PRs here or remove the section if this is a standalone PR.

[* https://github.com/elastic/.../pull/123-->](https://github.com/elastic/crawler/pull/349)
