### PR TITLE
[0.4] Revert the Docker.wolfi base image back to a known working version (#358)

### DIFF
--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,5 +1,5 @@
 # Build stage
-FROM docker.elastic.co/wolfi/jdk:openjdk-21.35-r1@sha256:56d69799450d02a898e3e6c3ffd2cd5f34931788abdf6a102d07035bcae0d3d3 AS builder
+FROM docker.elastic.co/wolfi/jdk:openjdk-21.35-r1@sha256:d7ca36452a68f28e4c4683062241e817b548844820a0ffd087451214e61eb188 AS builder
 
 USER root
 
@@ -55,7 +55,7 @@ RUN rm -rf .git .github .idea .devcontainer .buildkite
 
 # ------------------------------------------------------------------------------
 # Runtime stage - using the same base image
-FROM docker.elastic.co/wolfi/jdk:openjdk-21.35-r1@sha256:56d69799450d02a898e3e6c3ffd2cd5f34931788abdf6a102d07035bcae0d3d3
+FROM docker.elastic.co/wolfi/jdk:openjdk-21.35-r1@sha256:d7ca36452a68f28e4c4683062241e817b548844820a0ffd087451214e61eb188
 
 USER root
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `0.4`:
 - [Revert the Docker.wolfi base image back to a known working version (#358)](https://github.com/elastic/crawler/pull/358)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)