### PR TITLE
[CVE-2024-32002] Pin git version to 2.45.0 in Docker.wolfi

### DIFF
--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -68,7 +68,7 @@ ENV JAVA_HOME=/usr/lib/jvm/default-jvm \
     IS_DOCKER=1
 
 # Install runtime dependencies
-RUN apk update && apk add --no-cache libcurl-openssl4=~8.12.1
+RUN apk update && apk add --no-cache libcurl-openssl4=~8.12.1 git=~2.45.0
 
 
 # Copy JRuby, gem environment, and application from builder


### PR DESCRIPTION
This PR pins the Git version to `2.45.0`, as the base image uses `2.43.0` which is affected by `CVE-2024-32002`

### Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] This PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `crawler.yml.example` and `elasticsearch.yml.example`)
- [x] This PR has a meaningful title
- [ ] This PR links to all relevant GitHub issues that it fixes or partially addresses
    - If there is no GitHub issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [ ] Tested the changes locally
- [x] Added a label for each target release version (example: `v0.1.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] Ran `make notice` if any dependencies have been added
