### PR TITLE
[0.4] [CVE-2024-32002] Pin git version to 2.45.0 in Docker.wolfi (#362)

### DIFF
--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -68,7 +68,7 @@ ENV JAVA_HOME=/usr/lib/jvm/default-jvm \
     IS_DOCKER=1
 
 # Install runtime dependencies
-RUN apk update && apk add --no-cache libcurl-openssl4=~8.12.1
+RUN apk update && apk add --no-cache libcurl-openssl4=~8.12.1 git=~2.45.0
 
 
 # Copy JRuby, gem environment, and application from builder


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `0.4`:
 - [[CVE-2024-32002] Pin git version to 2.45.0 in Docker.wolfi (#362)](https://github.com/elastic/crawler/pull/362)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)