### PR TITLE
[0.4] [CVE-2025-6021] Bump nokogiri to 1.18.9 (#365)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ group :test do
   gem 'webrick', '~> 1.8.2'
 
   # Faux is a local gem for testing fake sites, requires nokogiri
-  gem 'nokogiri', '~> 1.18.8', require: false, platform: :jruby
+  gem 'nokogiri', '~> 1.18.9', require: false, platform: :jruby
   gem 'faux', path: 'vendor/faux', require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,7 @@ GEM
     method_source (1.1.0)
     minitest (5.22.3)
     multi_json (1.15.0)
-    nokogiri (1.18.8-java)
+    nokogiri (1.18.9-java)
       racc (~> 1.4)
     parallel (1.24.0)
     parser (3.3.1.0)
@@ -170,7 +170,7 @@ DEPENDENCIES
   ipaddr (~> 1.2.4)
   json (~> 2.7.2)
   json-schema (~> 4.3.0)
-  nokogiri (~> 1.18.8)
+  nokogiri (~> 1.18.9)
   pry (~> 0.14.2)
   pry-nav
   pry-remote


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `0.4`:
 - [[CVE-2025-6021] Bump nokogiri to 1.18.9 (#365)](https://github.com/elastic/crawler/pull/365)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)