### PR TITLE
[0.4] Build the wolfi image on CI (#357)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,3 +21,8 @@ steps:
     commands:
       - ".buildkite/scripts/run_command.sh docker"
       - ".buildkite/scripts/run_command.sh test"
+  - label: ":wolfi: Test Wolfi Image"
+    commands:
+      - ".buildkite/scripts/run_command.sh wolfi"
+      - "chmod +x .buildkite/scripts/test-wolfi-image.sh"
+      - ".buildkite/scripts/test-wolfi-image.sh"

--- a/.buildkite/scripts/run_command.sh
+++ b/.buildkite/scripts/run_command.sh
@@ -23,6 +23,9 @@ SCRIPT_CMD="/ci/.buildkite/scripts/run_ci_step.sh"
 if [[ "${COMMAND_TO_RUN:-}" == "docker" ]]; then
   echo "---- running docker build"
   make build-docker-ci
+elif [[ "${COMMAND_TO_RUN:-}" == "wolfi" ]]; then
+  echo "---- running wolfi docker build"
+  make build-docker-wolfi
 else
   docker run --interactive --rm             \
               --sig-proxy=true --init      \

--- a/.buildkite/scripts/test-wolfi-image.sh
+++ b/.buildkite/scripts/test-wolfi-image.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# Simple tests to verify Wolfi image functionality
+echo "Testing JRuby installation..."
+docker run --rm crawler-ci-wolfi ruby --version | grep -E "jruby\s9\.4\..*"
+
+echo "Testing crawler installation..."
+docker run --rm crawler-ci-wolfi jruby bin/crawler version
+
+echo "Wolfi image tests passed!"

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ notice:
 build-docker-ci:
 	docker build -t crawler-ci .
 
+build-docker-wolfi:
+	docker build -t crawler-ci-wolfi -f Dockerfile.wolfi .
+
 list-gems:
 	script/bundle exec gem dependency
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `0.4`:
 - [Build the wolfi image on CI (#357)](https://github.com/elastic/crawler/pull/357)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)