### PR TITLE
[0.4] Update docker.elastic.co/wolfi/chainguard-base:latest Docker digest to 5d0f094 (#382)

### DIFF
--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -63,7 +63,7 @@ RUN jlink \
 
 # ------------------------------------------------------------------------------
 # Runtime stage - using wolfi-base
-FROM docker.elastic.co/wolfi/chainguard-base:latest@sha256:661355310ab9ecc86082d247341881eb272853eb8fe4c91e53e02f0f2e30fb2c
+FROM docker.elastic.co/wolfi/chainguard-base:latest@sha256:5d0f094bdbe4fcc12416da5d48fdcafef1aecc101088038b6392231c697d9038
 
 USER root
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `0.4`:
 - [Update docker.elastic.co/wolfi/chainguard-base:latest Docker digest to 5d0f094 (#382)](https://github.com/elastic/crawler/pull/382)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)