### PR TITLE
[0.3] Update docker.elastic.co/wolfi/chainguard-base:latest Docker digest to 5d0f094 (#382)

### DIFF
--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -63,7 +63,7 @@ RUN jlink \
 
 # ------------------------------------------------------------------------------
 # Runtime stage - using wolfi-base
-FROM docker.elastic.co/wolfi/chainguard-base@sha256:3b2026fffccfc6223a9f49f09279e044008b64e30b948cee17f9a74143a2c850
+FROM docker.elastic.co/wolfi/chainguard-base:latest@sha256:5d0f094bdbe4fcc12416da5d48fdcafef1aecc101088038b6392231c697d9038
 
 USER root
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `0.3`:
 - [Update docker.elastic.co/wolfi/chainguard-base:latest Docker digest to 5d0f094 (#382)](https://github.com/elastic/crawler/pull/382)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)