### PR TITLE
[0.4] rack bump 2.2.20 manually

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ group :test do
 end
 
 group :development, :test do
-  gem 'rack', '~> 2.2.14'
+  gem 'rack', '~> 2.2.20'
   gem 'httpclient'
   gem 'pry', '~> 0.14.2', platform: :jruby
   gem 'factory_bot', '~> 6.2.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
     public_suffix (6.0.1)
     raabro (1.4.0)
     racc (1.7.3-java)
-    rack (2.2.16)
+    rack (2.2.20)
     rack-mount (0.8.3)
       rack (>= 1.0.0)
     rainbow (3.1.1)
@@ -175,7 +175,7 @@ DEPENDENCIES
   pry-nav
   pry-remote
   racc (~> 1.7.3)
-  rack (~> 2.2.14)
+  rack (~> 2.2.20)
   rexml (~> 3.4.0)
   rspec (~> 3.13.0)
   rubocop (~> 1.63)


### PR DESCRIPTION
Manually backporting https://github.com/elastic/crawler/pull/393 to 0.4