### PR TITLE
Bumps the chainguard image

### DIFF
--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,5 +1,5 @@
 # Build stage
-FROM docker.elastic.co/wolfi/jdk:openjdk-21.0.8-r1-dev@sha256:935bb066f36b48abf8e7dce4533cec6a0d62c24d4ec4073a5c95d282840028f9 AS builder
+FROM docker.elastic.co/wolfi/jdk:openjdk-21.0.10-jmods-dev AS builder
 USER root
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION

Renovate recently tried to bump the chainguard image, and it failed. See: https://github.com/elastic/crawler/pull/408

After some digging, Chainguard folks pointed us to https://support.chainguard.dev/hc/en-us/articles/40115158434587-Removal-of-jmods-from-JDK-development-images, which clarified that the artifact names had changed for images that include jmods. Since we use `jlink` in our image, we need to swap to the new image name patterns, so that renovate can keep us updated.

### Checklists



#### Pre-Review Checklist
- [x] This PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `crawler.yml.example` and `elasticsearch.yml.example`)
- [x] This PR has a meaningful title
- [x] this PR has a thorough description
- [x] Added a label for each target release version (example: `v0.1.0`)

