### PR TITLE
remove plexus-utils from production image due to CVE-2025-67030

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,11 @@ RUN make clean install
 # Clean up build dependencies
 RUN rm -r /home/crawleruser/.m2
 
+# Remove ruby-maven and ruby-maven-libs gems, which are only needed at build time
+# for JAR dependency resolution. This also removes the bundled plexus-utils-3.5.1.jar
+# (CVE-2025-67030) from the production image.
+RUN rm -rf /usr/local/bundle/gems/ruby-maven-* \
+    /usr/local/bundle/specifications/ruby-maven-* \
+    /usr/local/bundle/cache/ruby-maven-*
+
 ENTRYPOINT [ "/bin/bash" ]

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -52,6 +52,13 @@ RUN make clean install
 # add more directories and files not to be copied to the runtime image from /home/app
 RUN rm -rf .git .github .idea .devcontainer .buildkite
 
+# Remove ruby-maven and ruby-maven-libs gems, which are only needed at build time
+# for JAR dependency resolution. This also removes the bundled plexus-utils-3.5.1.jar
+# (CVE-2025-67030) from the production image.
+RUN rm -rf /usr/local/bundle/gems/ruby-maven-* \
+    /usr/local/bundle/specifications/ruby-maven-* \
+    /usr/local/bundle/cache/ruby-maven-*
+
 # Create custom JDK using jlink
 RUN jlink \
     --add-modules java.base,jdk.crypto.ec,java.logging,java.management,java.naming,java.net.http,java.scripting,java.security.jgss,java.security.sasl,java.sql,jdk.unsupported \


### PR DESCRIPTION
elastic/search-team#13576

plexus-utils-3.5.1.jar (CVE-2025-67030, directory traversal) is bundled inside ruby-maven-libs-3.9.9, which ships Apache Maven. Maven is only used at build time for JAR dependency resolution via jar-dependencies and is not needed at runtime.

This PR removes ruby-maven and ruby-maven-libs gems from both Docker images after the build step, eliminating the vulnerable library from the production artifact.

Verified locally:

plexus-utils-3.5.1.jar is no longer present in the built image
All default gems load successfully
Test suite passes (4 pre-existing sitemap test failures unrelated to this change)