### PR TITLE
Exclude dev and test deps from docker images

### DIFF
--- a/.buildkite/scripts/run_ci_step.sh
+++ b/.buildkite/scripts/run_ci_step.sh
@@ -8,6 +8,10 @@ JAVA_VERSION="$(cat .java-version)"
 export RUBY_VERSION
 export JAVA_VERSION
 
+# The Docker image excludes dev/test gems for a leaner production build.
+# CI needs them, so clear the 'without' config before installing.
+bundle config unset without
+
 case $1 in
   lint)
     echo "---- running linter"

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ RUN groupadd -g 451 crawlergroup && \
 USER crawleruser
 COPY --chown=crawleruser:crawlergroup --chmod=775 . /home/app
 WORKDIR /home/app
+# Exclude development and test gems from the production image to reduce
+# image size and CVE surface area (e.g. rack, rspec, rubocop, pry, etc.)
+RUN bundle config set --local without 'development test'
 RUN make clean install
 
 # Clean up build dependencies

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -48,6 +48,9 @@ WORKDIR /home/app
 # skip jenv/rbenv setup
 ENV IS_DOCKER=1
 
+# Exclude development and test gems from the production image to reduce
+# image size and CVE surface area (e.g. rack, rspec, rubocop, pry, etc.)
+RUN bundle config set --local without 'development test'
 RUN make clean install
 # add more directories and files not to be copied to the runtime image from /home/app
 RUN rm -rf .git .github .idea .devcontainer .buildkite


### PR DESCRIPTION
### Part of https://github.com/elastic/crawler/issues/430

Looks like we're not correctly stripping out our dev/test dependencies at build time.

After merging this, we probably need to cut a new release. 

### Checklists



#### Pre-Review Checklist
- [x] This PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `crawler.yml.example` and `elasticsearch.yml.example`)
- [x] This PR has a meaningful title
- [x] This PR links to all relevant GitHub issues that it fixes or partially addresses
    - If there is no GitHub issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [ ] Tested the changes locally
- [x] Added a label for each target release version (example: `v0.1.0`)
- [x] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] Ran `make notice` if any dependencies have been added



### Release Note

Fixes a packaging bug that was causing CVE scanners to flag false positives on Open Crawler
