### PR TITLE
Fix ES delay_on_retry behavior + clarify config example messaging

### DIFF
--- a/config/elasticsearch.yml.example
+++ b/config/elasticsearch.yml.example
@@ -78,9 +78,11 @@
 #elasticsearch.retry_on_failure: 3
 #
 #
-## The amount of time to wait between requests after a failure occurs.
-##    Default: 2000
-#elasticsearch.delay_on_retry: 10000
+## The amount of time, in seconds, to wait before the first retry after a failed
+##    Elasticsearch request. Each subsequent retry doubles this wait time, so a value of
+##    `2` produces a backoff sequence of 2s, 4s, 8s, ...
+##    Default: 2
+#elasticsearch.delay_on_retry: 10
 #
 #
 ## Whether to reload connections (refresh node list) after a connection failure.

--- a/lib/es/client.rb
+++ b/lib/es/client.rb
@@ -238,7 +238,10 @@ module ES
       rescue StandardError => e
         try += 1
         if try < max_tries
-          wait_time = @retry_delay**try
+          # Exponential backoff: the first retry waits @retry_delay seconds, and each
+          # subsequent retry doubles that wait (e.g. 2s, 4s, 8s, ...).
+          # See https://github.com/elastic/crawler/issues/380.
+          wait_time = @retry_delay * (2**(try - 1))
           @system_logger.warn(
             "#{description} attempt #{try}/#{max_tries} failed: '#{e.message}'. Retrying in #{wait_time.to_f}s.."
           )

--- a/spec/lib/es/client_spec.rb
+++ b/spec/lib/es/client_spec.rb
@@ -380,7 +380,7 @@ RSpec.describe(ES::Client) do
     end
 
     context 'when success requires retries' do
-      let(:config) { { elasticsearch: { host:, port:, retry_on_failure: 2, delay_on_retry: 1 } } }
+      let(:config) { { elasticsearch: { host:, port:, retry_on_failure: 2, delay_on_retry: 3 } } }
       let(:attempts) { instance_double(Proc) }
       let(:attempt_counter) { double(count: 0) }
 
@@ -396,13 +396,13 @@ RSpec.describe(ES::Client) do
 
       it 'succeeds after retrying, sleeps with exponential backoff, and logs warnings' do
         expect(system_logger).to receive(:warn).with(
-          %r{#{description} attempt 1/3 failed: 'Failed attempt 1'. Retrying in 1.0s..}
+          %r{#{description} attempt 1/3 failed: 'Failed attempt 1'. Retrying in 3.0s..}
         ).ordered
-        expect(subject).to receive(:sleep).with(1.0**1).ordered
+        expect(subject).to receive(:sleep).with(3).ordered
         expect(system_logger).to receive(:warn).with(
-          %r{#{description} attempt 2/3 failed: 'Failed attempt 2'. Retrying in 1.0s..}
+          %r{#{description} attempt 2/3 failed: 'Failed attempt 2'. Retrying in 6.0s..}
         ).ordered
-        expect(subject).to receive(:sleep).with(1.0**2).ordered
+        expect(subject).to receive(:sleep).with(6).ordered
         expect(system_logger).not_to receive(:error)
 
         result = execute_retry { block_spy.call }
@@ -413,7 +413,7 @@ RSpec.describe(ES::Client) do
     end
 
     context 'when all retries fail' do
-      let(:config) { { elasticsearch: { host:, port:, retry_on_failure: 2, delay_on_retry: 1 } } }
+      let(:config) { { elasticsearch: { host:, port:, retry_on_failure: 2, delay_on_retry: 3 } } }
 
       before do
         allow(block_spy).to receive(:call).and_raise(error_class, 'Persistent failure')
@@ -421,13 +421,13 @@ RSpec.describe(ES::Client) do
 
       it 'raises the original error after exhausting retries, sleeps, logs warnings and final error' do
         expect(system_logger).to receive(:warn).with(
-          %r{#{description} attempt 1/3 failed: 'Persistent failure'. Retrying in 1.0s..}
+          %r{#{description} attempt 1/3 failed: 'Persistent failure'. Retrying in 3.0s..}
         ).ordered
-        expect(subject).to receive(:sleep).with(1.0**1).ordered
+        expect(subject).to receive(:sleep).with(3).ordered
         expect(system_logger).to receive(:warn).with(
-          %r{#{description} attempt 2/3 failed: 'Persistent failure'. Retrying in 1.0s..}
+          %r{#{description} attempt 2/3 failed: 'Persistent failure'. Retrying in 6.0s..}
         ).ordered
-        expect(subject).to receive(:sleep).with(1.0**2).ordered
+        expect(subject).to receive(:sleep).with(6).ordered
         expect(system_logger).to receive(:error).with(
           /#{description} failed after 3 attempts: 'Persistent failure'/
         ).ordered
@@ -437,6 +437,30 @@ RSpec.describe(ES::Client) do
         end.to raise_error(error_class, 'Persistent failure')
 
         expect(block_spy).to have_received(:call).exactly(3).times
+      end
+    end
+
+    # Regression test for https://github.com/elastic/crawler/issues/380.
+    # Previously the code computed `wait_time = @retry_delay ** try`, which made a 60s
+    # delay jump to 3600s on the second retry. The backoff should instead double the
+    # configured delay each attempt: 60s -> 120s -> 240s.
+    context 'when delay_on_retry is large (regression for #380)' do
+      let(:config) { { elasticsearch: { host:, port:, retry_on_failure: 3, delay_on_retry: 60 } } }
+
+      before do
+        allow(block_spy).to receive(:call).and_raise(error_class, 'Persistent failure')
+      end
+
+      it 'doubles the configured delay each retry instead of exponentiating it' do
+        expect(subject).to receive(:sleep).with(60).ordered
+        expect(subject).to receive(:sleep).with(120).ordered
+        expect(subject).to receive(:sleep).with(240).ordered
+
+        expect do
+          execute_retry { block_spy.call }
+        end.to raise_error(error_class, 'Persistent failure')
+
+        expect(block_spy).to have_received(:call).exactly(4).times
       end
     end
 


### PR DESCRIPTION
### Closes https://github.com/elastic/crawler/issues/380

This PR fixes the `delay_on_retry` behavior within the Crawler's Elasticsearch client.

Previously, we were calculating

`retry_delay ** try_count`

where `**` in Ruby is an exponent operation, not multiplication. So, a retry delay of 10s goes
```
10s^1 = 10s
10s^2 = 100s
10x^3 = 1000s
```
which is too aggressive.

The new calculation correctly doubles the retry backoff time:

`retry_delay * (2^(try_count-1))`

Thus,
```
10s * (2^0) = 10s # try_count = 1
10s * (2^1) = 20s # try_count = 2, etc
10s * (2^2) = 40s
10s * (2^3) = 80s
```

The description of this config setting has been updated in `elasticsearch.yaml.example` as well. 

### Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] This PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `crawler.yml.example` and `elasticsearch.yml.example`)
- [x] This PR has a meaningful title
- [x] This PR links to all relevant GitHub issues that it fixes or partially addresses
    - If there is no GitHub issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v0.1.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference
- [x] Ran `make notice` if any dependencies have been added

### Related Pull Requests

<!--List any relevant PRs here or remove the section if this is a standalone PR.

* https://github.com/elastic/.../pull/123-->

### Release Note

Fix `elasticsearch.delay_on_retry` config setting to correctly double the retry backoff with every failure instead of exponentiation of the specified retry backoff time.