### PR TITLE
Fix for purge crawl failing if primary crawl comes up empty

### DIFF
--- a/lib/crawler/output_sink/elasticsearch.rb
+++ b/lib/crawler/output_sink/elasticsearch.rb
@@ -103,6 +103,10 @@ module Crawler
       end
 
       def fetch_purge_docs(crawl_start_time)
+        # `unmapped_type: 'date'` lets the search succeed when `last_crawled_at` has no
+        # mapping yet (e.g. the index was just created and the primary crawl indexed
+        # zero documents). Without it, ES returns a 400 query_shard_exception and the
+        # whole crawl fails. See https://github.com/elastic/crawler/issues/381.
         query = {
           _source: ['url'],
           query: {
@@ -113,7 +117,7 @@ module Crawler
             }
           },
           size: SEARCH_PAGINATION_SIZE,
-          sort: [{ last_crawled_at: 'asc' }]
+          sort: [{ last_crawled_at: { order: 'asc', unmapped_type: 'date' } }]
         }.deep_stringify_keys
         system_logger.debug(
           "Fetching docs for pages that were not encountered during the sync. Full query: #{query.inspect}"

--- a/spec/lib/crawler/output_sink/elasticsearch_spec.rb
+++ b/spec/lib/crawler/output_sink/elasticsearch_spec.rb
@@ -522,7 +522,7 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
           }
         },
         size: Crawler::OutputSink::Elasticsearch::SEARCH_PAGINATION_SIZE,
-        sort: [{ last_crawled_at: 'asc' }]
+        sort: [{ last_crawled_at: { order: 'asc', unmapped_type: 'date' } }]
       }.deep_stringify_keys
     end
     let(:hit1) do
@@ -556,6 +556,29 @@ RSpec.describe(Crawler::OutputSink::Elasticsearch) do
 
       results = subject.fetch_purge_docs(crawl_start_time)
       expect(results).to match_array(formatted_results)
+    end
+
+    # Regression test for https://github.com/elastic/crawler/issues/381.
+    # When the primary crawl indexes zero documents into a freshly-created index, the
+    # `last_crawled_at` field has no mapping yet. Without `unmapped_type: 'date'`, ES
+    # responds with a 400 query_shard_exception ("No mapping found for [last_crawled_at]
+    # in order to sort on") and the entire crawl fails after exhausting retries.
+    context 'when the index has no mapping for last_crawled_at (regression for #381)' do
+      it 'sorts with unmapped_type: date so the search succeeds against an empty index' do
+        expect(es_client).to receive(:paginated_search) do |_idx, query|
+          sort = query.fetch('sort').first.fetch('last_crawled_at')
+          expect(sort).to include('unmapped_type' => 'date', 'order' => 'asc')
+          es_results
+        end
+
+        subject.fetch_purge_docs(crawl_start_time)
+      end
+
+      it 'returns an empty array when the search returns no hits, allowing the coordinator to skip the purge' do
+        allow(es_client).to receive(:paginated_search).and_return([])
+
+        expect(subject.fetch_purge_docs(crawl_start_time)).to eq([])
+      end
     end
   end
 


### PR DESCRIPTION
### Closes https://github.com/elastic/crawler/issues/381

When the primary crawl finishes without indexing any documents into a freshly-created index (e.g. every page returns `4xx`, `robots.txt` is forbidden, the seed URL is unreachable, etc.), the index has no field mappings.

The purge phase then issues a search sorted by `last_crawled_at`, and Elasticsearch responds with `400 query_shard_exception: No mapping found for [last_crawled_at] in order to sort on`. The retry logic in `ES::Client#execute_with_retry` blindly re-issues the same bad query 4 times and then the entire crawl fails.

This PR fixes this by adding `unmapped_type: 'date'` to the sort clause in `fetch_purge_docs`. 

Per [the official Elasticsearch sort docs](https://www.elastic.co/docs/reference/elasticsearch/rest-apis/sort-search-results), this is the canonical idiom for telling ES "treat this field as a date if it has no mapping yet." With the fix, the search succeeds against an empty/unmapped index, returns 0 hits, and run_purge_crawl! in `Coordinator.rb` takes over and finishes the crawl successfully.

### Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] This PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `crawler.yml.example` and `elasticsearch.yml.example`)
- [x] This PR has a meaningful title
- [x] This PR links to all relevant GitHub issues that it fixes or partially addresses
    - If there is no GitHub issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v0.1.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference
- [x] Ran `make notice` if any dependencies have been added

### Release Note

Fixed a bug where a crawl would fail at the purge phase if the primary crawl didn't index any documents into a newly-created index.
