### PR TITLE
[CVE-2026-54297] Bump faraday to 2.14.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
       tzinfo
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
-    faraday (2.14.1)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger


### PR DESCRIPTION
### Relates to https://github.com/elastic/search-team/issues/14974

Resolves **CVE-2026-54297** (high) — uncontrolled recursion DoS in Faraday `NestedParamsEncoder#dehash` via deeply nested query parameters. Fixed in Faraday **2.14.3**.

#### Changes
- **`Gemfile.lock`**: bump transitive `faraday` `2.14.1` → `2.14.3` (pulled in by `elasticsearch` → `elastic-transport`).

#### Testing
- Full test suite: **690 examples, 0 failures, 16 pending**.
- Confirmed runtime Faraday version is `2.14.3`.

### Scanner A/B (`CVE-2026-54297`)

| Tool | Before | After |
|------|--------|-------|
| bundler-audit | n/a | n/a |
| Trivy | reported | clear |
| Snyk | reported | clear |

### Checklists

#### Pre-Review Checklist
- [x] This PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `crawler.yml.example` and `elasticsearch.yml.example`)
- [x] This PR has a meaningful title
- [x] This PR links to all relevant GitHub issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v0.1.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] Ran `make notice` if any dependencies have been added

#### Changes Requiring Extra Attention
- [x] Security-related changes (encryption, TLS, SSRF, etc)

### Release Note
Bump Faraday to 2.14.3 to resolve CVE-2026-54297 (uncontrolled recursion DoS in nested query parameter handling).

Made with [Cursor](https://cursor.com)