### PR TITLE
[CVE-2026-41316] Bump erb to 4.0.4.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,11 @@ group :default do
   gem 'elasticsearch', '~> 8.14.0'
   gem 'json-schema', '~> 4.3.0'
   gem 'rexml', '~> 3.4.2'
+
+  # Pin erb above JRuby 9.4's default erb 2.2.3 to fix CVE-2026-41316
+  # (@_init deserialization guard bypass via def_module/def_method/def_class).
+  # Use 4.0.4.1 (fixed line; 4.0.3.1 is also patched but some scanners still flag it).
+  gem 'erb', '4.0.4.1'
   gem 'rufus-scheduler', '~> 3.9.1'
 
   # jruby-openssl 0.16.0 bundles Bouncy Castle 1.84, fixing CVE-2026-5588.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,6 +21,7 @@ GEM
     ast (2.4.2)
     bigdecimal (3.1.8-java)
     bson (4.15.0-java)
+    cgi (0.5.2-java)
     coderay (1.1.3)
     concurrent-ruby (1.3.7)
     crack (1.0.0)
@@ -37,6 +38,8 @@ GEM
       elasticsearch-api (= 8.14.0)
     elasticsearch-api (8.14.0)
       multi_json
+    erb (4.0.4.1-java)
+      cgi (>= 0.3.3)
     et-orbi (1.2.11)
       tzinfo
     factory_bot (6.2.1)
@@ -166,6 +169,7 @@ DEPENDENCIES
   concurrent-ruby (~> 1.3.7)
   dry-cli (~> 0.7.0)
   elasticsearch (~> 8.14.0)
+  erb (= 4.0.4.1)
   factory_bot (~> 6.2.0)
   faux!
   httpclient

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -238,34 +238,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 --------------------------------------------------------------------------------
-Library: base64 0.2.0
-URL: https://github.com/ruby/base64
-License: Ruby OR BSD-2-Clause
-
-Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-1. Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-SUCH DAMAGE.
-
---------------------------------------------------------------------------------
 Library: bigdecimal 3.1.8
 URL: https://github.com/ruby/bigdecimal
 License: Ruby OR BSD-2-Clause
@@ -552,7 +524,35 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 --------------------------------------------------------------------------------
-Library: concurrent-ruby 1.1.10
+Library: cgi 0.5.2
+URL: https://github.com/ruby/cgi
+License: Ruby OR BSD-2-Clause
+
+Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+--------------------------------------------------------------------------------
+Library: concurrent-ruby 1.3.7
 URL: http://www.concurrent-ruby.com
 License: MIT
 
@@ -1229,6 +1229,34 @@ License: Apache-2.0
    limitations under the License.
 
 --------------------------------------------------------------------------------
+Library: erb 4.0.4.1
+URL: https://github.com/ruby/erb
+License: Ruby OR BSD-2-Clause
+
+Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+--------------------------------------------------------------------------------
 Library: et-orbi 1.2.11
 URL: https://github.com/floraison/et-orbi
 License: MIT
@@ -1259,7 +1287,7 @@ Made in Japan
 
 
 --------------------------------------------------------------------------------
-Library: faraday 2.8.1
+Library: faraday 2.14.3
 URL: https://lostisland.github.io/faraday
 License: MIT
 
@@ -1527,6 +1555,34 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 --------------------------------------------------------------------------------
+Library: logger 1.7.0
+URL: https://github.com/ruby/logger
+License: Ruby OR BSD-2-Clause
+
+Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+--------------------------------------------------------------------------------
 Library: minitest 5.22.3
 URL: https://github.com/minitest/minitest
 License: MIT
@@ -1693,34 +1749,6 @@ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
 LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
-
---------------------------------------------------------------------------------
-Library: ruby2_keywords 0.0.5
-URL: https://github.com/ruby/ruby2_keywords
-License: Ruby OR BSD-2-Clause
-
-Copyright 2019-2020 Nobuyoshi Nakada, Yusuke Endoh
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 Library: rufus-scheduler 3.9.1


### PR DESCRIPTION
### Part of https://github.com/elastic/security/issues/12737

Resolves **CVE-2026-41316** (high) — `@_init` deserialization guard bypass in ERB via `def_module` / `def_method` / `def_class`. Fixed in ERB **4.0.4.1**.

#### Changes
- **`Gemfile` / `Gemfile.lock`**: pin `erb` to `4.0.4.1` (overrides JRuby 9.4's default `erb` 2.2.3).
- **`NOTICE.txt`**: regenerated for the new dependency (and transitive `cgi`).

#### Testing
- Lint: no offenses.
- Full test suite: **690 examples, 16 pending**; one flaky locking spec unrelated to erb (passes on retry).
- Confirmed runtime ERB version is `4.0.4.1`.

### Scanner A/B (`CVE-2026-41316`)

| Tool | Before | After |
|------|--------|-------|
| Trivy | reported | clear |
| Snyk | reported | clear |

### Checklists

#### Pre-Review Checklist
- [x] This PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `crawler.yml.example` and `elasticsearch.yml.example`)
- [x] This PR has a meaningful title
- [x] This PR links to all relevant GitHub issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v0.1.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [x] Ran `make notice` if any dependencies have been added

#### Changes Requiring Extra Attention
- [x] Security-related changes (encryption, TLS, SSRF, etc)

### Release Note
Bump ERB to 4.0.4.1 to resolve CVE-2026-41316 (deserialization guard bypass).

Made with [Cursor](https://cursor.com)