### PR TITLE
[CVE-2026-42246] Pin net-imap 0.3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,15 +31,17 @@ RUN rm -rf /usr/local/bundle/gems/ruby-maven-* \
 
 # Drop the vulnerable Bouncy Castle 1.79 jars from JRuby's default jruby-openssl
 # 0.15.3 (CVE-2026-5588); the pinned 0.16.0 gem provides 1.84 at runtime.
-# Also drop JRuby's default net-imap 0.2.3 (CVE-2026-42246); the pinned 0.3.10
-# gem from the Gemfile provides the fixed version at runtime.
+# Also drop JRuby's vulnerable net-imap copies (CVE-2026-42246): the default
+# gem 0.2.3 and the older stdlib 0.1.1 (net/imap.rb). The pinned 0.3.10 gem
+# from the Gemfile provides the fixed version at runtime.
 # Needs root as /opt/jruby is root-owned.
 USER root
 RUN rm -rf /opt/jruby/lib/ruby/stdlib/org/bouncycastle \
     /opt/jruby/lib/ruby/gems/shared/gems/net-imap-0.2.3 \
     /opt/jruby/lib/ruby/gems/shared/specifications/net-imap-0.2.3.gemspec \
     /opt/jruby/lib/ruby/gems/shared/cache/net-imap-0.2.3.gem \
-    /opt/jruby/lib/ruby/stdlib/net/net-imap.gemspec
+    /opt/jruby/lib/ruby/stdlib/net/net-imap.gemspec \
+    /opt/jruby/lib/ruby/stdlib/net/imap.rb
 USER crawleruser
 
 ENTRYPOINT [ "/bin/bash" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,15 @@ RUN rm -rf /usr/local/bundle/gems/ruby-maven-* \
 
 # Drop the vulnerable Bouncy Castle 1.79 jars from JRuby's default jruby-openssl
 # 0.15.3 (CVE-2026-5588); the pinned 0.16.0 gem provides 1.84 at runtime.
+# Also drop JRuby's default net-imap 0.2.3 (CVE-2026-42246); the pinned 0.3.10
+# gem from the Gemfile provides the fixed version at runtime.
 # Needs root as /opt/jruby is root-owned.
 USER root
-RUN rm -rf /opt/jruby/lib/ruby/stdlib/org/bouncycastle
+RUN rm -rf /opt/jruby/lib/ruby/stdlib/org/bouncycastle \
+    /opt/jruby/lib/ruby/gems/shared/gems/net-imap-0.2.3 \
+    /opt/jruby/lib/ruby/gems/shared/specifications/net-imap-0.2.3.gemspec \
+    /opt/jruby/lib/ruby/gems/shared/cache/net-imap-0.2.3.gem \
+    /opt/jruby/lib/ruby/stdlib/net/net-imap.gemspec
 USER crawleruser
 
 ENTRYPOINT [ "/bin/bash" ]

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -64,14 +64,16 @@ RUN rm -rf /usr/local/bundle/gems/ruby-maven-* \
 
 # Drop the vulnerable Bouncy Castle 1.79 jars from JRuby's default jruby-openssl
 # 0.15.3 (CVE-2026-5588); the pinned 0.16.0 gem provides 1.84 at runtime.
-# Also drop JRuby's default net-imap 0.2.3 (CVE-2026-42246); the pinned 0.3.10
-# gem from the Gemfile provides the fixed version at runtime.
+# Also drop JRuby's vulnerable net-imap copies (CVE-2026-42246): the default
+# gem 0.2.3 and the older stdlib 0.1.1 (net/imap.rb). The pinned 0.3.10 gem
+# from the Gemfile provides the fixed version at runtime.
 # Done in the builder stage, before /opt/jruby is copied into the runtime image.
 RUN rm -rf /opt/jruby/lib/ruby/stdlib/org/bouncycastle \
     /opt/jruby/lib/ruby/gems/shared/gems/net-imap-0.2.3 \
     /opt/jruby/lib/ruby/gems/shared/specifications/net-imap-0.2.3.gemspec \
     /opt/jruby/lib/ruby/gems/shared/cache/net-imap-0.2.3.gem \
-    /opt/jruby/lib/ruby/stdlib/net/net-imap.gemspec
+    /opt/jruby/lib/ruby/stdlib/net/net-imap.gemspec \
+    /opt/jruby/lib/ruby/stdlib/net/imap.rb
 
 # Create custom JDK using jlink
 RUN jlink \

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -64,8 +64,14 @@ RUN rm -rf /usr/local/bundle/gems/ruby-maven-* \
 
 # Drop the vulnerable Bouncy Castle 1.79 jars from JRuby's default jruby-openssl
 # 0.15.3 (CVE-2026-5588); the pinned 0.16.0 gem provides 1.84 at runtime.
+# Also drop JRuby's default net-imap 0.2.3 (CVE-2026-42246); the pinned 0.3.10
+# gem from the Gemfile provides the fixed version at runtime.
 # Done in the builder stage, before /opt/jruby is copied into the runtime image.
-RUN rm -rf /opt/jruby/lib/ruby/stdlib/org/bouncycastle
+RUN rm -rf /opt/jruby/lib/ruby/stdlib/org/bouncycastle \
+    /opt/jruby/lib/ruby/gems/shared/gems/net-imap-0.2.3 \
+    /opt/jruby/lib/ruby/gems/shared/specifications/net-imap-0.2.3.gemspec \
+    /opt/jruby/lib/ruby/gems/shared/cache/net-imap-0.2.3.gem \
+    /opt/jruby/lib/ruby/stdlib/net/net-imap.gemspec
 
 # Create custom JDK using jlink
 RUN jlink \

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,10 @@ group :default do
   # JRuby 9.4.12.0's default jruby-openssl 0.15.3 ships the vulnerable 1.79.
   gem 'jruby-openssl', '0.16.0', platform: :jruby
 
+  # JRuby 9.4.12.0 ships net-imap 0.2.3 as a default gem (CVE-2026-42246 STARTTLS
+  # stripping). Pin the lowest fixed release so Bundler installs over the default.
+  gem 'net-imap', '0.3.10'
+
   # Gems that need jruby as the platform
   gem 'bson', '~> 4.15.0', platform: :jruby
   gem 'bigdecimal', '~> 3.1.7', platform: :jruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,6 +26,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
+    date (3.5.1-java)
     diff-lcs (1.5.1)
     docile (1.4.0)
     dry-cli (0.7.0)
@@ -64,6 +65,11 @@ GEM
     method_source (1.1.0)
     minitest (5.22.3)
     multi_json (1.15.0)
+    net-imap (0.3.10)
+      date
+      net-protocol
+    net-protocol (0.2.2)
+      timeout
     nokogiri (1.18.9-java)
       racc (~> 1.4)
     parallel (1.24.0)
@@ -137,6 +143,7 @@ GEM
       ffi
     strscan (3.1.0-java)
     thread_safe (0.3.6-java)
+    timeout (0.6.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2024.1)
@@ -173,6 +180,7 @@ DEPENDENCIES
   jruby-openssl (= 0.16.0)
   json (~> 2.7.2)
   json-schema (~> 4.3.0)
+  net-imap (= 0.3.10)
   nokogiri (~> 1.18.9)
   pry (~> 0.14.2)
   pry-nav

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -238,34 +238,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 --------------------------------------------------------------------------------
-Library: base64 0.2.0
-URL: https://github.com/ruby/base64
-License: Ruby OR BSD-2-Clause
-
-Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-1. Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-SUCH DAMAGE.
-
---------------------------------------------------------------------------------
 Library: bigdecimal 3.1.8
 URL: https://github.com/ruby/bigdecimal
 License: Ruby OR BSD-2-Clause
@@ -524,7 +496,7 @@ License: Apache-2.0
    limitations under the License.
 
 --------------------------------------------------------------------------------
-Library: bundler 2.6.6
+Library: bundler 2.6.3
 URL: https://bundler.io
 License: MIT
 
@@ -552,7 +524,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 --------------------------------------------------------------------------------
-Library: concurrent-ruby 1.1.10
+Library: concurrent-ruby 1.3.7
 URL: http://www.concurrent-ruby.com
 License: MIT
 
@@ -577,6 +549,68 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+--------------------------------------------------------------------------------
+Library: date 3.5.1
+URL: https://github.com/ruby/date
+License: Ruby OR BSD-2-Clause
+
+Ruby is copyrighted free software by Yukihiro Matsumoto <matz@netlab.jp>.
+You can redistribute it and/or modify it under either the terms of the
+2-clause BSDL (see the file BSDL), or the conditions below:
+
+1. You may make and give away verbatim copies of the source form of the
+   software without restriction, provided that you duplicate all of the
+   original copyright notices and associated disclaimers.
+
+2. You may modify your copy of the software in any way, provided that
+   you do at least ONE of the following:
+
+   a. place your modifications in the Public Domain or otherwise
+      make them Freely Available, such as by posting said
+      modifications to Usenet or an equivalent medium, or by allowing
+      the author to include your modifications in the software.
+
+   b. use the modified software only within your corporation or
+      organization.
+
+   c. give non-standard binaries non-standard names, with
+      instructions on where to get the original software distribution.
+
+   d. make other distribution arrangements with the author.
+
+3. You may distribute the software in object code or binary form,
+   provided that you do at least ONE of the following:
+
+   a. distribute the binaries and library files of the software,
+      together with instructions (in the manual page or equivalent)
+      on where to get the original distribution.
+
+   b. accompany the distribution with the machine-readable source of
+      the software.
+
+   c. give non-standard binaries non-standard names, with
+      instructions on where to get the original software distribution.
+
+   d. make other distribution arrangements with the author.
+
+4. You may modify and include the part of the software into any other
+   software (possibly commercial).  But some files in the distribution
+   are not written by the author, so that they are not under these terms.
+
+   For the list of those files and their copying conditions, see the
+   file LEGAL.
+
+5. The scripts and library files supplied as input to or produced as
+   output from the software do not automatically fall under the
+   copyright of the software, but belong to whomever generated them,
+   and may be sold commercially, and may be aggregated with this
+   software.
+
+6. THIS SOFTWARE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR
+   IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+   PURPOSE.
 
 --------------------------------------------------------------------------------
 Library: dry-cli 0.7.0
@@ -1259,7 +1293,7 @@ Made in Japan
 
 
 --------------------------------------------------------------------------------
-Library: faraday 2.8.1
+Library: faraday 2.14.3
 URL: https://lostisland.github.io/faraday
 License: MIT
 
@@ -1527,6 +1561,34 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 --------------------------------------------------------------------------------
+Library: logger 1.7.0
+URL: https://github.com/ruby/logger
+License: Ruby OR BSD-2-Clause
+
+Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+--------------------------------------------------------------------------------
 Library: minitest 5.22.3
 URL: https://github.com/minitest/minitest
 License: MIT
@@ -1579,6 +1641,124 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+--------------------------------------------------------------------------------
+Library: net-imap 0.3.10
+URL: https://github.com/ruby/net-imap
+License: Ruby OR BSD-2-Clause
+
+Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+-------------------------------------------------------------------------
+
+This software includes documentation which has been copied from the relevant
+RFCs.  The copied documentation is covered by the following licenses:
+
+RFC 3501 (Editor: M. Crispin)
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2003).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.  v This
+   document and the information contained herein is provided on an "AS
+   IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING TASK
+   FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+   LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION HEREIN WILL
+   NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF MERCHANTABILITY
+   OR FITNESS FOR A PARTICULAR PURPOSE.
+
+
+RFC9051 (Editors: A. Melnikov, B. Leiba)
+Copyright Notice
+
+   Copyright (c) 2021 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (https://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+   This document may contain material from IETF Documents or IETF
+   Contributions published or made publicly available before November
+   10, 2008.  The person(s) controlling the copyright in some of this
+   material may not have granted the IETF Trust the right to allow
+   modifications of such material outside the IETF Standards Process.
+   Without obtaining an adequate license from the person(s) controlling
+   the copyright in such materials, this document may not be modified
+   outside the IETF Standards Process, and derivative works of it may
+   not be created outside the IETF Standards Process, except to format
+   it for publication as an RFC or to translate it into languages other
+   than English.
+
+--------------------------------------------------------------------------------
+Library: net-protocol 0.2.2
+URL: https://github.com/ruby/net-protocol
+License: Ruby OR BSD-2-Clause
+
+Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 Library: public_suffix 6.0.1
@@ -1693,34 +1873,6 @@ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
 LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
-
---------------------------------------------------------------------------------
-Library: ruby2_keywords 0.0.5
-URL: https://github.com/ruby/ruby2_keywords
-License: Ruby OR BSD-2-Clause
-
-Copyright 2019-2020 Nobuyoshi Nakada, Yusuke Endoh
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 Library: rufus-scheduler 3.9.1
@@ -1926,6 +2078,34 @@ claims asserted against, such Contributor by reason of your accepting any such w
 additional liability.
 
 END OF TERMS AND CONDITIONS
+
+--------------------------------------------------------------------------------
+Library: timeout 0.6.1
+URL: https://github.com/ruby/timeout
+License: Ruby OR BSD-2-Clause
+
+Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 Library: tzinfo 2.0.6

--- a/script/licenses/lib/third_party/rubygems_dependencies.rb
+++ b/script/licenses/lib/third_party/rubygems_dependencies.rb
@@ -130,7 +130,11 @@ module ThirdParty
       'webrick' => { url: 'http://www.ruby-lang.org/en/LICENSE.txt' },
 
       # https://github.com/ruby/strscan/blob/master/LICENSE.txt
-      'strscan' => { url: 'https://raw.githubusercontent.com/ruby/strscan/master/LICENSE.txt' }
+      'strscan' => { url: 'https://raw.githubusercontent.com/ruby/strscan/master/LICENSE.txt' },
+
+      # https://github.com/ruby/date/tree/v3.5.1
+      # The java platform gem build ships without license files in the gem package.
+      'date' => { url: 'https://raw.githubusercontent.com/ruby/date/v3.5.1/COPYING' }
     }.freeze
   end
 end


### PR DESCRIPTION
### Part of https://github.com/elastic/security/issues/12735

Resolves **CVE-2026-42246** (high) — STARTTLS stripping / response injection in `Net::IMAP#starttls`. Fixed in net-imap **0.3.10**.

JRuby 9.4.12.0 ships vulnerable net-imap in two places: the default gem **0.2.3** and an older stdlib copy **0.1.1** (`net/imap.rb`). The crawler does not use IMAP; this change removes both from the images and pins the fixed gem so scanners and runtime use 0.3.10.

#### Changes
- **`Gemfile` / `Gemfile.lock`**: pin `net-imap` `0.3.10` (lowest fixed release) so Bundler installs over the JRuby default gem.
- **`Dockerfile` / `Dockerfile.wolfi`**: remove the default `net-imap` 0.2.3 gem artifacts **and** the older stdlib `net/imap.rb` (0.1.1) from `/opt/jruby`.
- **`NOTICE.txt`**: regenerated for the new gems (`make notice`); added a `date` license-file fallback.

#### Testing
- Full test suite (JRuby 9.4.12.0 image): **690 examples, 0 failures, 16 pending**.
- Confirmed runtime net-imap version is `0.3.10` (`vendor/bundle/.../net-imap-0.3.10`).
- Confirmed the post-cleanup image has no remaining `*imap*` files under `/opt/jruby`, and the app still loads 0.3.10 via `bundler/setup`.

### Scanner A/B (`CVE-2026-42246`)

| Tool | Before | After |
|------|--------|-------|
| Trivy | reported | clear |
| Snyk | reported (SNYK-RUBY-NETIMAP-16420230) | clear |

### Checklists

#### Pre-Review Checklist
- [x] This PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `crawler.yml.example` and `elasticsearch.yml.example`)
- [x] This PR has a meaningful title
- [x] This PR links to all relevant GitHub issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v0.1.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [x] Ran `make notice` if any dependencies have been added

#### Changes Requiring Extra Attention
- [x] Security-related changes (encryption, TLS, SSRF, etc)

### Release Note
Pin net-imap to 0.3.10 to resolve CVE-2026-42246 (STARTTLS stripping in Net::IMAP).