### PR TITLE
fix(ci): grant explicit GITHUB_TOKEN permissions to workflows

### DIFF
--- a/.github/workflows/add-labels-main.yml
+++ b/.github/workflows/add-labels-main.yml
@@ -7,8 +7,7 @@ on:
     types:
       - opened
 
-# The repository default is read-only, so the scopes this job needs must be
-# granted here: checkout reads product_version; the action labels the PR.
+# Override read-only GITHUB_TOKEN default: label newly opened PRs.
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/add-labels-main.yml
+++ b/.github/workflows/add-labels-main.yml
@@ -7,6 +7,12 @@ on:
     types:
       - opened
 
+# The repository default is read-only, so the scopes this job needs must be
+# granted here: checkout reads product_version; the action labels the PR.
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   add_labels:
     runs-on: ubuntu-latest

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -8,6 +8,14 @@ on:
       - labeled
       - closed
 
+# The repository default is read-only, so the scopes this job needs must be
+# granted here: the backport action pushes cherry-pick branches, opens the
+# backport PRs, and comments the result back on the source PR. Approving the
+# backport PRs uses REPO_SCOPED_TOKEN, not GITHUB_TOKEN.
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   backport:
     if: |

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -8,10 +8,7 @@ on:
       - labeled
       - closed
 
-# The repository default is read-only, so the scopes this job needs must be
-# granted here: the backport action pushes cherry-pick branches, opens the
-# backport PRs, and comments the result back on the source PR. Approving the
-# backport PRs uses REPO_SCOPED_TOKEN, not GITHUB_TOKEN.
+# Override read-only GITHUB_TOKEN default: push backport branches and comment on PRs.
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
### Closes https://github.com/elastic/crawler/issues/465

Same failure mode as [elastic/connectors#4289](https://github.com/elastic/connectors/pull/4289).

The repository's default `GITHUB_TOKEN` permission is now read-only:

```text
$ gh api repos/elastic/crawler/actions/permissions/workflow
{"default_workflow_permissions":"read","can_approve_pull_request_reviews":true}
```

Neither workflow in `.github/workflows/` declared a `permissions:` block, so they inherit that default. After merging #462, backport failed with:

1. `Permission to elastic/crawler.git denied to github-actions[bot]` on `git push` of the backport branch (`contents: write` missing)
2. `Resource not accessible by integration` when posting the failure comment on the source PR (`pull-requests: write` missing)

This declares the scopes each workflow actually needs (least privilege), overriding the read-only default without flipping the repository setting back to read/write for everything.

| Workflow | Scopes | Why |
|----------|--------|-----|
| `add-labels-main.yml` | `contents: read`, `pull-requests: write` | checkout reads `product_version`; action labels the PR |
| `backport.yml` | `contents: write`, `pull-requests: write` | pushes cherry-pick branches, opens backport PRs, comments status on the source PR |

`backport.yml`'s `approver_token` (`REPO_SCOPED_TOKEN`) is unaffected by the `GITHUB_TOKEN` default.

### Note on verifying this PR

`pull_request_target` always runs the workflow from the **base** branch, so backport/add-labels will still use `main`'s copy (without permissions) while this PR is open. The fix takes effect only after merge. After merge, re-trigger backport for any PRs that failed (e.g. #462) by re-adding the `auto-backport` label, or run the manual command from the failure comment.

### Checklists

#### Pre-Review Checklist
- [x] This PR does NOT contain credentials of any kind
- [x] This PR has a meaningful title
- [x] This PR links to all relevant GitHub issues
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests (no workflow YAML test harness)
- [x] Tested the changes locally (YAML structure + permissions blocks verified)
- [x] Added a label for each target release version
- [ ] Considered corresponding documentation changes

Deliberately **not** labelled `auto-backport`: both workflows are gated on `branches: main`, so copies on maintenance branches never run.

#### Changes Requiring Extra Attention
- [x] Security-related changes — both workflows use `pull_request_target`. Grants are safe: neither checks out or executes PR head code. `add-labels-main.yml` checks out the base ref and only reads `product_version`. `backport.yml` checks out a pinned external actions repo and only runs after merge into `main`.

### Release Note

No user-facing change; CI configuration only.

Made with [Cursor](https://cursor.com)